### PR TITLE
fix: context details url

### DIFF
--- a/src/components/context/RowItem.tsx
+++ b/src/components/context/RowItem.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from 'react-router-dom';
 import styled from "styled-components";
 import MenuIconDropdown from "../common/MenuIconDropdown";
 import { ContextObject } from "../../pages/Contexts";
@@ -66,9 +65,9 @@ export default function rowItem(
 ): JSX.Element {
   return (
     <RowItem key={item.id} $hasBorders={id === count}>
-      <Link to={item.id} className="row-item id">
+      <a href={`contexts/${item.id}`} className="row-item id">
         {item.id}
-      </Link>
+      </a>
       <div className="row-item name">{item.name}</div>
       <div className="menu-dropdown">
         <MenuIconDropdown


### PR DESCRIPTION
# fix: context details url

## Summary:
Clicking on context in the context list on the context page would navigate you to broken url that looked like 
`/contexts#contexts/{id]`
One solution is to use <a> tag with full url path `href="/admin-dashboard/contexts/[id]"` or use <Link> with just `to="id"`

Used second solution and :` this approach leverages React Router's internal mechanisms for handling routing, which can help avoid issues with URL paths and ensure consistent navigation behavior across your application.`


https://github.com/calimero-network/admin-dashboard/assets/93442516/3aefe626-f8a7-48bf-a7fb-a68e575a2c22

Passing build:
<img width="1067" alt="Screenshot 2024-06-12 at 16 06 10" src="https://github.com/calimero-network/admin-dashboard/assets/93442516/93321794-e7b8-4e45-add3-0fa5971edb1e">
