### PR TITLE
fix: menu dropdown css

### DIFF
--- a/src/components/common/MenuIconDropdown.tsx
+++ b/src/components/common/MenuIconDropdown.tsx
@@ -4,6 +4,8 @@ import Dropdown from 'react-bootstrap/Dropdown';
 import styled from 'styled-components';
 
 const DropdownWrapper = styled.div`
+  position: relative;
+
   .app-dropdown {
     background-color: transparent;
     border: none;
@@ -38,6 +40,7 @@ const DropdownWrapper = styled.div`
 
   .dropdown-container {
     padding: 0;
+    position: absolute;
 
     .menu-dropdown {
       width: 100%;


### PR DESCRIPTION
# fix: menu dropdown css

## Summary:
This was fixed already before but was overwritten somewhere in the process of switching to new repo. 
Dropdown was going out of screen and menu item has scroll. 

https://github.com/calimero-network/admin-dashboard/assets/93442516/c8917236-3a4c-43b4-a8b5-fa57d4660a93

