### PR TITLE
fix: update api return types

### DIFF
--- a/src/api/dataSource/NodeDataSource.ts
+++ b/src/api/dataSource/NodeDataSource.ts
@@ -172,7 +172,7 @@ export class NodeDataSource {
 
   async getContextClientKeys(
     contextId: string,
-  ): Promise<ResponseData<ContextClientKeysList>> {
+  ): ApiResponse<ContextClientKeysList> {
     try {
       const headers: Header | null = await createAuthHeader(
         contextId,
@@ -193,7 +193,7 @@ export class NodeDataSource {
 
   async getContextUsers(
     contextId: string,
-  ): Promise<ResponseData<ContextUsersList>> {
+  ): ApiResponse<ContextUsersList> {
     try {
       const headers: Header | null = await createAuthHeader(
         contextId,
@@ -214,7 +214,7 @@ export class NodeDataSource {
 
   async getContextStorageUsage(
     contextId: string,
-  ): Promise<ResponseData<ContextStorage>> {
+  ): ApiResponse<ContextStorage> {
     try {
       const headers: Header | null = await createAuthHeader(
         contextId,

--- a/src/api/dataSource/NodeDataSource.ts
+++ b/src/api/dataSource/NodeDataSource.ts
@@ -191,9 +191,7 @@ export class NodeDataSource {
     }
   }
 
-  async getContextUsers(
-    contextId: string,
-  ): ApiResponse<ContextUsersList> {
+  async getContextUsers(contextId: string): ApiResponse<ContextUsersList> {
     try {
       const headers: Header | null = await createAuthHeader(
         contextId,
@@ -212,9 +210,7 @@ export class NodeDataSource {
     }
   }
 
-  async getContextStorageUsage(
-    contextId: string,
-  ): ApiResponse<ContextStorage> {
+  async getContextStorageUsage(contextId: string): ApiResponse<ContextStorage> {
     try {
       const headers: Header | null = await createAuthHeader(
         contextId,


### PR DESCRIPTION
# fix: update api return types

## Summary:
In the nodeAPI return types were already defined as ApiResponse which is Promise<ResponseData<T>>