### PR TITLE
feat: redirect on error bug

### DIFF
--- a/src/components/protectedRoutes/ProtectedRoute.tsx
+++ b/src/components/protectedRoutes/ProtectedRoute.tsx
@@ -1,23 +1,23 @@
 import React, { useEffect } from 'react';
 import { useNavigate, Outlet } from 'react-router-dom';
-import { getClientKey } from '../../utils/storage';
+import { isNodeAuthorized } from '../../utils/storage';
 import { getPathname } from '../../utils/protectedRoute';
 
 export default function ProtectedRoute() {
   const navigate = useNavigate();
-  const clientKey = getClientKey();
+  const isAuthorized = isNodeAuthorized();
   const pathname = getPathname();
 
   useEffect(() => {
     const isAuthPath = pathname.startsWith('/auth');
-    if (clientKey) {
+    if (isAuthorized) {
       if (isAuthPath) {
         navigate('/identity');
       }
     } else {
       navigate('/auth');
     }
-  }, [clientKey]);
+  }, [isAuthorized]);
 
   return <Outlet />;
 }

--- a/src/components/protectedRoutes/ProtectedRoute.tsx
+++ b/src/components/protectedRoutes/ProtectedRoute.tsx
@@ -1,23 +1,24 @@
 import React, { useEffect } from 'react';
 import { useNavigate, Outlet } from 'react-router-dom';
-import { isNodeAuthorized } from '../../utils/storage';
+import { isNodeAuthorized, getClientKey } from '../../utils/storage';
 import { getPathname } from '../../utils/protectedRoute';
 
 export default function ProtectedRoute() {
   const navigate = useNavigate();
+  const clientKey = getClientKey();
   const isAuthorized = isNodeAuthorized();
   const pathname = getPathname();
 
   useEffect(() => {
     const isAuthPath = pathname.startsWith('/auth');
-    if (isAuthorized) {
+    if (isAuthorized && clientKey) {
       if (isAuthPath) {
         navigate('/identity');
       }
     } else {
       navigate('/auth');
     }
-  }, [isAuthorized]);
+  }, [isAuthorized, clientKey]);
 
   return <Outlet />;
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -4,6 +4,7 @@ import { ResponseData } from '../api/response';
 
 export const APP_URL = 'app-url';
 const AUTHORIZED = 'node-authorized';
+const CLIENT_KEY = 'client-key';
 const NODE_URL = 'node-url';
 
 export const getAppEndpointKey = (): string | null => {
@@ -25,6 +26,10 @@ export const getAppEndpointKey = (): string | null => {
 
 export const setAppEndpointKey = (url: string) => {
   localStorage.setItem(APP_URL, JSON.stringify(url));
+};
+
+export const getClientKey = (): String => {
+  return localStorage.getItem(CLIENT_KEY) ?? '';
 };
 
 export const isNodeAuthorized = (): boolean => {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -3,7 +3,7 @@ import { HealthStatus } from '../api/dataSource/NodeDataSource';
 import { ResponseData } from '../api/response';
 
 export const APP_URL = 'app-url';
-const CLIENT_KEY = 'client-key';
+const AUTHORIZED = 'node-authorized';
 const NODE_URL = 'node-url';
 
 export const getAppEndpointKey = (): string | null => {
@@ -27,8 +27,9 @@ export const setAppEndpointKey = (url: string) => {
   localStorage.setItem(APP_URL, JSON.stringify(url));
 };
 
-export const getClientKey = (): String => {
-  return localStorage.getItem(CLIENT_KEY) ?? '';
+export const isNodeAuthorized = (): boolean => {
+  const authorized = localStorage.getItem(AUTHORIZED);
+  return authorized ? JSON.parse(authorized) : false;
 };
 
 export const setNodeUrlFromQuery = async () => {


### PR DESCRIPTION
# feat: redirect on error bug

## Summary:
The issue with login was that the wrong local storage parameter was checked. 
The client key is saved to the storage before calling the api "add-client-key" or "root-key" and it was redirecting to protected routes acting as the auth was successful. 

Video after and before fix

https://github.com/calimero-network/admin-dashboard/assets/93442516/5a8f132a-985c-42a9-8449-f601a6f759d5


https://github.com/calimero-network/admin-dashboard/assets/93442516/885a9ada-c36d-4f75-836a-d919e597891d

