### PR TITLE
refactor: enable context preview with dev app

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@calimero-is-near/calimero-p2p-sdk": "0.0.26",
+    "@calimero-is-near/calimero-p2p-sdk": "0.0.27",
     "@floating-ui/react-native": "^0.10.4",
     "@heroicons/react": "^2.1.3",
     "@near-wallet-selector/core": "^8.9.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,10 +9,10 @@ importers:
     dependencies:
       '@calimero-is-near/calimero-p2p-sdk':
         specifier: 0.0.26
-        version: 0.0.26(@near-wallet-selector/modal-ui@8.9.8(near-api-js@3.0.4))(@types/react@18.3.3)(bufferutil@4.0.8)(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(rollup@4.13.0)(typescript@5.4.5)(utf-8-validate@6.0.4)
+        version: 0.0.26(@near-wallet-selector/modal-ui@8.9.8(near-api-js@3.0.4))(@types/react@18.3.3)(bufferutil@4.0.8)(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(rollup@4.13.0)(typescript@5.4.5)
       '@floating-ui/react-native':
         specifier: ^0.10.4
-        version: 0.10.4(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)
+        version: 0.10.4(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)
       '@heroicons/react':
         specifier: ^2.1.3
         version: 2.1.3(react@18.3.1)
@@ -39,13 +39,13 @@ importers:
         version: 8.9.8(near-api-js@3.0.4)
       '@near-wallet-selector/nightly-connect':
         specifier: ^8.7.0
-        version: 8.7.0(bufferutil@4.0.8)(near-api-js@3.0.4)(utf-8-validate@6.0.4)
+        version: 8.7.0(bufferutil@4.0.8)(near-api-js@3.0.4)
       '@near-wallet-selector/sender':
         specifier: ^8.9.5
         version: 8.9.8(near-api-js@3.0.4)
       '@near-wallet-selector/wallet-connect':
         specifier: ^8.9.5
-        version: 8.9.8(@types/react@18.3.3)(bufferutil@4.0.8)(near-api-js@3.0.4)(react@18.3.1)(utf-8-validate@6.0.4)
+        version: 8.9.8(@types/react@18.3.3)(bufferutil@4.0.8)(near-api-js@3.0.4)(react@18.3.1)
       '@types/node':
         specifier: ^18.7.14
         version: 18.19.34
@@ -10915,10 +10915,10 @@ packages:
       typescript:
         optional: true
 
-  viem@2.16.5:
+  viem@2.17.3:
     resolution:
       {
-        integrity: sha512-QDESALYDyLSP+pIr7adH3QPZ+3is16aOVMXXZE0X1GVbgL7PDMZQ8xIF1X/B1hgyqkBl2HhMpUaq6ksUdBV/YA==,
+        integrity: sha512-FY/1uBQWfko4Esy8mU1RamvL64TLy91LZwFyQJ20E6AI3vTTEOctWfSn0pkMKa3okq4Gxs5dJE7q1hmWOQ7xcw==,
       }
     peerDependencies:
       typescript: '>=5.0.4'
@@ -12446,12 +12446,12 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
-  '@calimero-is-near/calimero-p2p-sdk@0.0.26(@near-wallet-selector/modal-ui@8.9.8(near-api-js@3.0.4))(@types/react@18.3.3)(bufferutil@4.0.8)(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(rollup@4.13.0)(typescript@5.4.5)(utf-8-validate@6.0.4)':
+  '@calimero-is-near/calimero-p2p-sdk@0.0.26(@near-wallet-selector/modal-ui@8.9.8(near-api-js@3.0.4))(@types/react@18.3.3)(bufferutil@4.0.8)(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(rollup@4.13.0)(typescript@5.4.5)':
     dependencies:
       '@libp2p/crypto': 4.1.2
       '@libp2p/interface': 1.4.0
       '@libp2p/peer-id': 4.1.2
-      '@metamask/sdk-react-ui': 0.20.4(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)(rollup@4.13.0)(typescript@5.4.5)(utf-8-validate@6.0.4)
+      '@metamask/sdk-react-ui': 0.20.4(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)(rollup@4.13.0)(typescript@5.4.5)
       '@near-wallet-selector/account-export': 8.9.8(near-api-js@3.0.4)
       '@near-wallet-selector/core': 8.9.8(near-api-js@3.0.4)
       '@near-wallet-selector/modal-ui': 8.9.8(near-api-js@3.0.4)
@@ -12770,7 +12770,7 @@ snapshots:
     dependencies:
       '@ethersproject/logger': 5.7.0
 
-  '@ethersproject/providers@5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@ethersproject/providers@5.7.2(bufferutil@4.0.8)':
     dependencies:
       '@ethersproject/abstract-provider': 5.7.0
       '@ethersproject/abstract-signer': 5.7.0
@@ -12791,7 +12791,7 @@ snapshots:
       '@ethersproject/transactions': 5.7.0
       '@ethersproject/web': 5.7.1
       bech32: 1.1.4
-      ws: 7.4.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 7.4.6(bufferutil@4.0.8)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -12897,11 +12897,11 @@ snapshots:
       '@floating-ui/core': 1.6.0
       '@floating-ui/utils': 0.2.1
 
-  '@floating-ui/react-native@0.10.4(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)':
+  '@floating-ui/react-native@0.10.4(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/core': 1.6.0
       react: 18.3.1
-      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4)
+      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)
 
   '@floating-ui/utils@0.2.1': {}
 
@@ -13105,7 +13105,7 @@ snapshots:
 
   '@metamask/safe-event-emitter@3.1.1': {}
 
-  '@metamask/sdk-communication-layer@0.20.5(cross-fetch@4.0.0)(eciesjs@0.3.18)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8)(utf-8-validate@6.0.4))':
+  '@metamask/sdk-communication-layer@0.20.5(cross-fetch@4.0.0)(eciesjs@0.3.18)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8))':
     dependencies:
       bufferutil: 4.0.8
       cross-fetch: 4.0.0
@@ -13114,35 +13114,35 @@ snapshots:
       eciesjs: 0.3.18
       eventemitter2: 6.4.9
       readable-stream: 3.6.2
-      socket.io-client: 4.7.5(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      socket.io-client: 4.7.5(bufferutil@4.0.8)
       utf-8-validate: 6.0.4
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
 
-  '@metamask/sdk-install-modal-web@0.20.4(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)':
+  '@metamask/sdk-install-modal-web@0.20.4(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)':
     dependencies:
       i18next: 22.5.1
       qr-code-styling: 1.6.0-rc.1
-      react-i18next: 13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)
+      react-i18next: 13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4)
+      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)
 
-  '@metamask/sdk-react-ui@0.20.4(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)(rollup@4.13.0)(typescript@5.4.5)(utf-8-validate@6.0.4)':
+  '@metamask/sdk-react-ui@0.20.4(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)(rollup@4.13.0)(typescript@5.4.5)':
     dependencies:
       '@headlessui/react': 1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@metamask/sdk': 0.20.5(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)(rollup@4.13.0)(utf-8-validate@6.0.4)
-      '@metamask/sdk-react': 0.20.4(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)(rollup@4.13.0)(utf-8-validate@6.0.4)
-      ethers: 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@metamask/sdk': 0.20.5(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)(rollup@4.13.0)
+      '@metamask/sdk-react': 0.20.4(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)(rollup@4.13.0)
+      ethers: 5.7.2(bufferutil@4.0.8)
       mersenne-twister: 1.1.0
       react: 18.3.1
       react-copy-to-clipboard: 5.1.0(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
       react-jazzicon: 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      viem: 2.16.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)
-      wagmi: 1.4.12(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)(typescript@5.4.5)(utf-8-validate@6.0.4)(viem@2.16.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4))
+      viem: 2.17.3(bufferutil@4.0.8)(typescript@5.4.5)
+      wagmi: 1.4.12(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)(typescript@5.4.5)(viem@2.17.3(bufferutil@4.0.8)(typescript@5.4.5))
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -13170,9 +13170,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@metamask/sdk-react@0.20.4(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)(rollup@4.13.0)(utf-8-validate@6.0.4)':
+  '@metamask/sdk-react@0.20.4(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)(rollup@4.13.0)':
     dependencies:
-      '@metamask/sdk': 0.20.5(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)(rollup@4.13.0)(utf-8-validate@6.0.4)
+      '@metamask/sdk': 0.20.5(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)(rollup@4.13.0)
       debug: 4.3.4
       eth-rpc-errors: 4.0.3
       react: 18.3.1
@@ -13180,7 +13180,7 @@ snapshots:
       rollup-plugin-node-builtins: 2.1.2
       rollup-plugin-node-globals: 1.4.0
     optionalDependencies:
-      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4)
+      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -13189,12 +13189,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@metamask/sdk@0.20.5(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)(rollup@4.13.0)(utf-8-validate@6.0.4)':
+  '@metamask/sdk@0.20.5(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)(rollup@4.13.0)':
     dependencies:
       '@metamask/onboarding': 1.0.1
       '@metamask/providers': 15.0.0
-      '@metamask/sdk-communication-layer': 0.20.5(cross-fetch@4.0.0)(eciesjs@0.3.18)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8)(utf-8-validate@6.0.4))
-      '@metamask/sdk-install-modal-web': 0.20.4(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)
+      '@metamask/sdk-communication-layer': 0.20.5(cross-fetch@4.0.0)(eciesjs@0.3.18)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8))
+      '@metamask/sdk-install-modal-web': 0.20.4(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)
       '@types/dom-screen-wake-lock': 1.0.3
       bowser: 2.11.0
       cross-fetch: 4.0.0
@@ -13207,10 +13207,10 @@ snapshots:
       obj-multiplex: 1.0.0
       pump: 3.0.0
       qrcode-terminal-nooctal: 0.12.1
-      react-native-webview: 11.26.1(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)
+      react-native-webview: 11.26.1(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)
       readable-stream: 3.6.2
       rollup-plugin-visualizer: 5.12.0(rollup@4.13.0)
-      socket.io-client: 4.7.5(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      socket.io-client: 4.7.5(bufferutil@4.0.8)
       util: 0.12.5
       uuid: 8.3.2
     optionalDependencies:
@@ -13504,11 +13504,11 @@ snapshots:
       '@near-wallet-selector/my-near-wallet': 8.9.3(near-api-js@3.0.4)
       near-api-js: 3.0.4
 
-  '@near-wallet-selector/nightly-connect@8.7.0(bufferutil@4.0.8)(near-api-js@3.0.4)(utf-8-validate@6.0.4)':
+  '@near-wallet-selector/nightly-connect@8.7.0(bufferutil@4.0.8)(near-api-js@3.0.4)':
     dependencies:
       '@near-wallet-selector/core': 8.7.0(near-api-js@3.0.4)
       '@near-wallet-selector/wallet-utils': 8.7.0(near-api-js@3.0.4)
-      '@nightlylabs/connect-near': 0.0.15(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@nightlylabs/connect-near': 0.0.15(bufferutil@4.0.8)
       near-api-js: 3.0.4
     transitivePeerDependencies:
       - bufferutil
@@ -13528,12 +13528,12 @@ snapshots:
       is-mobile: 4.0.0
       near-api-js: 3.0.4
 
-  '@near-wallet-selector/wallet-connect@8.9.8(@types/react@18.3.3)(bufferutil@4.0.8)(near-api-js@3.0.4)(react@18.3.1)(utf-8-validate@6.0.4)':
+  '@near-wallet-selector/wallet-connect@8.9.8(@types/react@18.3.3)(bufferutil@4.0.8)(near-api-js@3.0.4)(react@18.3.1)':
     dependencies:
       '@near-wallet-selector/core': 8.9.8(near-api-js@3.0.4)
       '@near-wallet-selector/wallet-utils': 8.9.8(near-api-js@3.0.4)
       '@walletconnect/modal': 2.6.2(@types/react@18.3.3)(react@18.3.1)
-      '@walletconnect/sign-client': 2.11.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@walletconnect/sign-client': 2.11.0(bufferutil@4.0.8)
       '@walletconnect/types': 2.11.0
       near-api-js: 3.0.4
     transitivePeerDependencies:
@@ -13585,14 +13585,14 @@ snapshots:
     dependencies:
       eslint-scope: 5.1.1
 
-  '@nightlylabs/connect-near@0.0.15(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@nightlylabs/connect-near@0.0.15(bufferutil@4.0.8)':
     dependencies:
       '@nightlylabs/qr-code': 1.0.21
       isomorphic-localstorage: 0.0.8
-      isomorphic-ws: 4.0.1(ws@8.17.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))
+      isomorphic-ws: 4.0.1(ws@8.17.0(bufferutil@4.0.8))
       near-api-js: 0.45.1
       uuid: 8.3.2
-      ws: 8.17.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 8.17.0(bufferutil@4.0.8)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -13779,7 +13779,7 @@ snapshots:
 
   '@react-native-community/cli-plugin-metro@12.3.6': {}
 
-  '@react-native-community/cli-server-api@12.3.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@react-native-community/cli-server-api@12.3.6(bufferutil@4.0.8)':
     dependencies:
       '@react-native-community/cli-debugger-ui': 12.3.6
       '@react-native-community/cli-tools': 12.3.6
@@ -13789,7 +13789,7 @@ snapshots:
       nocache: 3.0.4
       pretty-format: 26.6.2
       serve-static: 1.15.0
-      ws: 7.5.9(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 7.5.9(bufferutil@4.0.8)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -13815,7 +13815,7 @@ snapshots:
     dependencies:
       joi: 17.12.2
 
-  '@react-native-community/cli@12.3.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@react-native-community/cli@12.3.6(bufferutil@4.0.8)':
     dependencies:
       '@react-native-community/cli-clean': 12.3.6
       '@react-native-community/cli-config': 12.3.6
@@ -13823,7 +13823,7 @@ snapshots:
       '@react-native-community/cli-doctor': 12.3.6
       '@react-native-community/cli-hermes': 12.3.6
       '@react-native-community/cli-plugin-metro': 12.3.6
-      '@react-native-community/cli-server-api': 12.3.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@react-native-community/cli-server-api': 12.3.6(bufferutil@4.0.8)
       '@react-native-community/cli-tools': 12.3.6
       '@react-native-community/cli-types': 12.3.6
       chalk: 4.1.2
@@ -13911,16 +13911,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/community-cli-plugin@0.73.17(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@react-native/community-cli-plugin@0.73.17(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)':
     dependencies:
-      '@react-native-community/cli-server-api': 12.3.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@react-native-community/cli-server-api': 12.3.6(bufferutil@4.0.8)
       '@react-native-community/cli-tools': 12.3.6
-      '@react-native/dev-middleware': 0.73.8(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@react-native/dev-middleware': 0.73.8(bufferutil@4.0.8)
       '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))
       chalk: 4.1.2
       execa: 5.1.1
-      metro: 0.80.8(bufferutil@4.0.8)(utf-8-validate@6.0.4)
-      metro-config: 0.80.8(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      metro: 0.80.8(bufferutil@4.0.8)
+      metro-config: 0.80.8(bufferutil@4.0.8)
       metro-core: 0.80.8
       node-fetch: 2.7.0
       readline: 1.3.0
@@ -13934,7 +13934,7 @@ snapshots:
 
   '@react-native/debugger-frontend@0.73.3': {}
 
-  '@react-native/dev-middleware@0.73.8(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@react-native/dev-middleware@0.73.8(bufferutil@4.0.8)':
     dependencies:
       '@isaacs/ttlcache': 1.4.1
       '@react-native/debugger-frontend': 0.73.3
@@ -13946,7 +13946,7 @@ snapshots:
       open: 7.4.2
       serve-static: 1.15.0
       temp-dir: 2.0.0
-      ws: 6.2.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 6.2.2(bufferutil@4.0.8)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -13969,11 +13969,11 @@ snapshots:
 
   '@react-native/normalize-colors@0.73.2': {}
 
-  '@react-native/virtualized-lists@0.73.4(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))':
+  '@react-native/virtualized-lists@0.73.4(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
-      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4)
+      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)
 
   '@remix-run/router@1.15.3': {}
 
@@ -14053,9 +14053,9 @@ snapshots:
 
   '@rushstack/eslint-patch@1.10.3': {}
 
-  '@safe-global/safe-apps-provider@0.18.2(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)':
+  '@safe-global/safe-apps-provider@0.18.2(bufferutil@4.0.8)(typescript@5.4.5)':
     dependencies:
-      '@safe-global/safe-apps-sdk': 9.0.0(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)
+      '@safe-global/safe-apps-sdk': 9.0.0(bufferutil@4.0.8)(typescript@5.4.5)
       events: 3.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -14063,20 +14063,20 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-sdk@8.1.0(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)':
+  '@safe-global/safe-apps-sdk@8.1.0(bufferutil@4.0.8)(typescript@5.4.5)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.21.1
-      viem: 1.21.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)
+      viem: 1.21.4(bufferutil@4.0.8)(typescript@5.4.5)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-sdk@9.0.0(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)':
+  '@safe-global/safe-apps-sdk@9.0.0(bufferutil@4.0.8)(typescript@5.4.5)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.21.1
-      viem: 1.21.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)
+      viem: 1.21.4(bufferutil@4.0.8)(typescript@5.4.5)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -14234,19 +14234,19 @@ snapshots:
     dependencies:
       '@tanstack/query-persist-client-core': 4.36.1
 
-  '@tanstack/react-query-persist-client@4.36.1(@tanstack/react-query@4.36.1(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))':
+  '@tanstack/react-query-persist-client@4.36.1(@tanstack/react-query@4.36.1(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@tanstack/query-persist-client-core': 4.36.1
-      '@tanstack/react-query': 4.36.1(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)
+      '@tanstack/react-query': 4.36.1(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)
 
-  '@tanstack/react-query@4.36.1(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)':
+  '@tanstack/react-query@4.36.1(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/query-core': 4.36.1
       react: 18.3.1
       use-sync-external-store: 1.2.0(react@18.3.1)
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
-      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4)
+      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)
 
   '@tanstack/react-virtual@3.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -14565,18 +14565,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@wagmi/connectors@3.1.10(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.4.5)(utf-8-validate@6.0.4)(viem@2.16.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4))':
+  '@wagmi/connectors@3.1.10(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.4.5)(viem@2.17.3(bufferutil@4.0.8)(typescript@5.4.5))':
     dependencies:
       '@coinbase/wallet-sdk': 3.9.3
-      '@safe-global/safe-apps-provider': 0.18.2(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)
-      '@safe-global/safe-apps-sdk': 8.1.0(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)
-      '@walletconnect/ethereum-provider': 2.10.6(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4)
+      '@safe-global/safe-apps-provider': 0.18.2(bufferutil@4.0.8)(typescript@5.4.5)
+      '@safe-global/safe-apps-sdk': 8.1.0(bufferutil@4.0.8)(typescript@5.4.5)
+      '@walletconnect/ethereum-provider': 2.10.6(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)
       '@walletconnect/legacy-provider': 2.0.0
       '@walletconnect/modal': 2.6.2(@types/react@18.3.3)(react@18.3.1)
       '@walletconnect/utils': 2.10.2
       abitype: 0.8.7(typescript@5.4.5)
       eventemitter3: 4.0.7
-      viem: 2.16.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)
+      viem: 2.17.3(bufferutil@4.0.8)(typescript@5.4.5)
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -14602,12 +14602,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@wagmi/core@1.4.12(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.4.5)(utf-8-validate@6.0.4)(viem@2.16.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4))':
+  '@wagmi/core@1.4.12(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.4.5)(viem@2.17.3(bufferutil@4.0.8)(typescript@5.4.5))':
     dependencies:
-      '@wagmi/connectors': 3.1.10(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.4.5)(utf-8-validate@6.0.4)(viem@2.16.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4))
+      '@wagmi/connectors': 3.1.10(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.4.5)(viem@2.17.3(bufferutil@4.0.8)(typescript@5.4.5))
       abitype: 0.8.7(typescript@5.4.5)
       eventemitter3: 4.0.7
-      viem: 2.16.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)
+      viem: 2.17.3(bufferutil@4.0.8)(typescript@5.4.5)
       zustand: 4.5.2(@types/react@18.3.3)(react@18.3.1)
     optionalDependencies:
       typescript: 5.4.5
@@ -14635,13 +14635,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.10.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@walletconnect/core@2.10.6(bufferutil@4.0.8)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.1
       '@walletconnect/jsonrpc-provider': 1.0.13
       '@walletconnect/jsonrpc-types': 1.0.3
       '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/jsonrpc-ws-connection': 1.0.14(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@walletconnect/jsonrpc-ws-connection': 1.0.14(bufferutil@4.0.8)
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
       '@walletconnect/relay-api': 1.0.10
@@ -14671,13 +14671,13 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  '@walletconnect/core@2.11.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@walletconnect/core@2.11.0(bufferutil@4.0.8)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.1
       '@walletconnect/jsonrpc-provider': 1.0.13
       '@walletconnect/jsonrpc-types': 1.0.3
       '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/jsonrpc-ws-connection': 1.0.14(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@walletconnect/jsonrpc-ws-connection': 1.0.14(bufferutil@4.0.8)
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
       '@walletconnect/relay-api': 1.0.10
@@ -14728,16 +14728,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/ethereum-provider@2.10.6(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4)':
+  '@walletconnect/ethereum-provider@2.10.6(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)':
     dependencies:
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.13
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/modal': 2.6.2(@types/react@18.3.3)(react@18.3.1)
-      '@walletconnect/sign-client': 2.10.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@walletconnect/sign-client': 2.10.6(bufferutil@4.0.8)
       '@walletconnect/types': 2.10.6
-      '@walletconnect/universal-provider': 2.10.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@walletconnect/universal-provider': 2.10.6(bufferutil@4.0.8)
       '@walletconnect/utils': 2.10.6
       events: 3.3.0
     transitivePeerDependencies:
@@ -14803,12 +14803,12 @@ snapshots:
       '@walletconnect/jsonrpc-types': 1.0.4
       tslib: 1.14.1
 
-  '@walletconnect/jsonrpc-ws-connection@1.0.14(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@walletconnect/jsonrpc-ws-connection@1.0.14(bufferutil@4.0.8)':
     dependencies:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/safe-json': 1.0.2
       events: 3.3.0
-      ws: 7.5.9(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 7.5.9(bufferutil@4.0.8)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -14934,9 +14934,9 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.10.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@walletconnect/sign-client@2.10.6(bufferutil@4.0.8)':
     dependencies:
-      '@walletconnect/core': 2.10.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@walletconnect/core': 2.10.6(bufferutil@4.0.8)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.1
       '@walletconnect/jsonrpc-utils': 1.0.8
@@ -14963,9 +14963,9 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  '@walletconnect/sign-client@2.11.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@walletconnect/sign-client@2.11.0(bufferutil@4.0.8)':
     dependencies:
-      '@walletconnect/core': 2.11.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@walletconnect/core': 2.11.0(bufferutil@4.0.8)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.1
       '@walletconnect/jsonrpc-utils': 1.0.8
@@ -15069,14 +15069,14 @@ snapshots:
       - ioredis
       - uWebSockets.js
 
-  '@walletconnect/universal-provider@2.10.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@walletconnect/universal-provider@2.10.6(bufferutil@4.0.8)':
     dependencies:
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.13
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.10.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@walletconnect/sign-client': 2.10.6(bufferutil@4.0.8)
       '@walletconnect/types': 2.10.6
       '@walletconnect/utils': 2.10.6
       events: 3.3.0
@@ -16256,12 +16256,12 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  engine.io-client@6.5.3(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  engine.io-client@6.5.3(bufferutil@4.0.8):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.3.4
       engine.io-parser: 5.2.2
-      ws: 8.11.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 8.11.0(bufferutil@4.0.8)
       xmlhttprequest-ssl: 2.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -16769,7 +16769,7 @@ snapshots:
       '@scure/bip32': 1.3.3
       '@scure/bip39': 1.2.2
 
-  ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  ethers@5.7.2(bufferutil@4.0.8):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/abstract-provider': 5.7.0
@@ -16789,7 +16789,7 @@ snapshots:
       '@ethersproject/networks': 5.7.1
       '@ethersproject/pbkdf2': 5.7.0
       '@ethersproject/properties': 5.7.0
-      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)
       '@ethersproject/random': 5.7.0
       '@ethersproject/rlp': 5.7.0
       '@ethersproject/sha2': 5.7.0
@@ -17440,17 +17440,17 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  isomorphic-ws@4.0.1(ws@8.17.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)):
+  isomorphic-ws@4.0.1(ws@8.17.0(bufferutil@4.0.8)):
     dependencies:
-      ws: 8.17.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 8.17.0(bufferutil@4.0.8)
 
-  isows@1.0.3(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)):
+  isows@1.0.3(ws@8.13.0(bufferutil@4.0.8)):
     dependencies:
-      ws: 8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 8.13.0(bufferutil@4.0.8)
 
-  isows@1.0.4(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)):
+  isows@1.0.4(ws@8.17.1(bufferutil@4.0.8)):
     dependencies:
-      ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 8.17.1(bufferutil@4.0.8)
 
   it-pushable@3.2.3:
     dependencies:
@@ -17873,12 +17873,12 @@ snapshots:
       metro-core: 0.80.8
       rimraf: 3.0.2
 
-  metro-config@0.80.8(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  metro-config@0.80.8(bufferutil@4.0.8):
     dependencies:
       connect: 3.7.0
       cosmiconfig: 5.2.1
       jest-validate: 29.7.0
-      metro: 0.80.8(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      metro: 0.80.8(bufferutil@4.0.8)
       metro-cache: 0.80.8
       metro-core: 0.80.8
       metro-runtime: 0.80.8
@@ -17954,13 +17954,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-worker@0.80.8(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  metro-transform-worker@0.80.8(bufferutil@4.0.8):
     dependencies:
       '@babel/core': 7.24.3
       '@babel/generator': 7.24.7
       '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
-      metro: 0.80.8(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      metro: 0.80.8(bufferutil@4.0.8)
       metro-babel-transformer: 0.80.8
       metro-cache: 0.80.8
       metro-cache-key: 0.80.8
@@ -17974,7 +17974,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro@0.80.8(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  metro@0.80.8(bufferutil@4.0.8):
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/core': 7.24.3
@@ -18000,7 +18000,7 @@ snapshots:
       metro-babel-transformer: 0.80.8
       metro-cache: 0.80.8
       metro-cache-key: 0.80.8
-      metro-config: 0.80.8(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      metro-config: 0.80.8(bufferutil@4.0.8)
       metro-core: 0.80.8
       metro-file-map: 0.80.8
       metro-resolver: 0.80.8
@@ -18008,7 +18008,7 @@ snapshots:
       metro-source-map: 0.80.8
       metro-symbolicate: 0.80.8
       metro-transform-plugins: 0.80.8
-      metro-transform-worker: 0.80.8(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      metro-transform-worker: 0.80.8(bufferutil@4.0.8)
       mime-types: 2.1.35
       node-fetch: 2.7.0
       nullthrows: 1.1.1
@@ -18017,7 +18017,7 @@ snapshots:
       source-map: 0.5.7
       strip-ansi: 6.0.1
       throat: 5.0.0
-      ws: 7.5.9(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 7.5.9(bufferutil@4.0.8)
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
@@ -18715,10 +18715,10 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
 
-  react-devtools-core@4.28.5(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  react-devtools-core@4.28.5(bufferutil@4.0.8):
     dependencies:
       shell-quote: 1.8.1
-      ws: 7.5.9(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 7.5.9(bufferutil@4.0.8)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -18735,7 +18735,7 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1):
+  react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.24.1
       html-parse-stringify: 3.0.1
@@ -18743,7 +18743,7 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
-      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4)
+      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)
 
   react-is@16.13.1: {}
 
@@ -18759,26 +18759,26 @@ snapshots:
 
   react-lifecycles-compat@3.0.4: {}
 
-  react-native-webview@11.26.1(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1):
+  react-native-webview@11.26.1(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1):
     dependencies:
       escape-string-regexp: 2.0.0
       invariant: 2.2.4
       react: 18.3.1
-      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4)
+      react-native: 0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)
 
-  react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4):
+  react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
-      '@react-native-community/cli': 12.3.6(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@react-native-community/cli': 12.3.6(bufferutil@4.0.8)
       '@react-native-community/cli-platform-android': 12.3.6
       '@react-native-community/cli-platform-ios': 12.3.6
       '@react-native/assets-registry': 0.73.1
       '@react-native/codegen': 0.73.3(@babel/preset-env@7.24.3(@babel/core@7.24.3))
-      '@react-native/community-cli-plugin': 0.73.17(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      '@react-native/community-cli-plugin': 0.73.17(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)
       '@react-native/gradle-plugin': 0.73.4
       '@react-native/js-polyfills': 0.73.1
       '@react-native/normalize-colors': 0.73.2
-      '@react-native/virtualized-lists': 0.73.4(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))
+      '@react-native/virtualized-lists': 0.73.4(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -18798,14 +18798,14 @@ snapshots:
       pretty-format: 26.6.2
       promise: 8.3.0
       react: 18.3.1
-      react-devtools-core: 4.28.5(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      react-devtools-core: 4.28.5(bufferutil@4.0.8)
       react-refresh: 0.14.0
       react-shallow-renderer: 16.15.0(react@18.3.1)
       regenerator-runtime: 0.13.11
       scheduler: 0.24.0-canary-efb381bbf-20230505
       stacktrace-parser: 0.1.10
       whatwg-fetch: 3.6.20
-      ws: 6.2.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      ws: 6.2.2(bufferutil@4.0.8)
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -19205,11 +19205,11 @@ snapshots:
 
   slide@1.1.6: {}
 
-  socket.io-client@4.7.5(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  socket.io-client@4.7.5(bufferutil@4.0.8):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.3.4
-      engine.io-client: 6.5.3(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      engine.io-client: 6.5.3(bufferutil@4.0.8)
       socket.io-parser: 4.2.4
     transitivePeerDependencies:
       - bufferutil
@@ -19704,7 +19704,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@1.21.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4):
+  viem@1.21.4(bufferutil@4.0.8)(typescript@5.4.5):
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
       '@noble/curves': 1.2.0
@@ -19712,8 +19712,8 @@ snapshots:
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
       abitype: 0.9.8(typescript@5.4.5)
-      isows: 1.0.3(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))
-      ws: 8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      isows: 1.0.3(ws@8.13.0(bufferutil@4.0.8))
+      ws: 8.13.0(bufferutil@4.0.8)
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -19721,7 +19721,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.16.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4):
+  viem@2.17.3(bufferutil@4.0.8)(typescript@5.4.5):
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
       '@noble/curves': 1.4.0
@@ -19729,8 +19729,8 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
       abitype: 1.0.5(typescript@5.4.5)
-      isows: 1.0.4(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@6.0.4))
-      ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      isows: 1.0.4(ws@8.17.1(bufferutil@4.0.8))
+      ws: 8.17.1(bufferutil@4.0.8)
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -19764,16 +19764,16 @@ snapshots:
 
   void-elements@3.1.0: {}
 
-  wagmi@1.4.12(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)(typescript@5.4.5)(utf-8-validate@6.0.4)(viem@2.16.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)):
+  wagmi@1.4.12(@types/react@18.3.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)(typescript@5.4.5)(viem@2.17.3(bufferutil@4.0.8)(typescript@5.4.5)):
     dependencies:
       '@tanstack/query-sync-storage-persister': 4.36.1
-      '@tanstack/react-query': 4.36.1(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1)
-      '@tanstack/react-query-persist-client': 4.36.1(@tanstack/react-query@4.36.1(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.4))(react@18.3.1))
-      '@wagmi/core': 1.4.12(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.4.5)(utf-8-validate@6.0.4)(viem@2.16.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4))
+      '@tanstack/react-query': 4.36.1(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-query-persist-client': 4.36.1(@tanstack/react-query@4.36.1(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))
+      '@wagmi/core': 1.4.12(@types/react@18.3.3)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.4.5)(viem@2.17.3(bufferutil@4.0.8)(typescript@5.4.5))
       abitype: 0.8.7(typescript@5.4.5)
       react: 18.3.1
       use-sync-external-store: 1.2.0(react@18.3.1)
-      viem: 2.16.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)
+      viem: 2.17.3(bufferutil@4.0.8)(typescript@5.4.5)
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -19932,42 +19932,35 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
 
-  ws@6.2.2(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  ws@6.2.2(bufferutil@4.0.8):
     dependencies:
       async-limiter: 1.0.1
     optionalDependencies:
       bufferutil: 4.0.8
-      utf-8-validate: 6.0.4
 
-  ws@7.4.6(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  ws@7.4.6(bufferutil@4.0.8):
     optionalDependencies:
       bufferutil: 4.0.8
-      utf-8-validate: 6.0.4
 
-  ws@7.5.9(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  ws@7.5.9(bufferutil@4.0.8):
     optionalDependencies:
       bufferutil: 4.0.8
-      utf-8-validate: 6.0.4
 
-  ws@8.11.0(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  ws@8.11.0(bufferutil@4.0.8):
     optionalDependencies:
       bufferutil: 4.0.8
-      utf-8-validate: 6.0.4
 
-  ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  ws@8.13.0(bufferutil@4.0.8):
     optionalDependencies:
       bufferutil: 4.0.8
-      utf-8-validate: 6.0.4
 
-  ws@8.17.0(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  ws@8.17.0(bufferutil@4.0.8):
     optionalDependencies:
       bufferutil: 4.0.8
-      utf-8-validate: 6.0.4
 
-  ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  ws@8.17.1(bufferutil@4.0.8):
     optionalDependencies:
       bufferutil: 4.0.8
-      utf-8-validate: 6.0.4
 
   xmlhttprequest-ssl@2.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
   .:
     dependencies:
       '@calimero-is-near/calimero-p2p-sdk':
-        specifier: 0.0.26
-        version: 0.0.26(@near-wallet-selector/modal-ui@8.9.8(near-api-js@3.0.4))(@types/react@18.3.3)(bufferutil@4.0.8)(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(rollup@4.13.0)(typescript@5.4.5)
+        specifier: 0.0.27
+        version: 0.0.27(@near-wallet-selector/modal-ui@8.9.8(near-api-js@3.0.4))(@types/react@18.3.3)(bufferutil@4.0.8)(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(rollup@4.13.0)(typescript@5.4.5)
       '@floating-ui/react-native':
         specifier: ^0.10.4
         version: 0.10.4(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1)
@@ -1531,10 +1531,10 @@ packages:
       }
     engines: { node: '>=6.9.0' }
 
-  '@calimero-is-near/calimero-p2p-sdk@0.0.26':
+  '@calimero-is-near/calimero-p2p-sdk@0.0.27':
     resolution:
       {
-        integrity: sha512-z6NzRtlQK21lLfT+QBSbVW8oSIlQp93iiuy2e5hbNbnx38AxD9DHvHz6M/CyFT5hCUd2Tg7nczIkUxd8HoPkjA==,
+        integrity: sha512-2K7pVsFl4o+Mq3bm6MG4zaEGGiYfhS5BQ3Kjrj5fBxNLw1PmWcY6/bGcgsKHMokJe6oXhf+vTIMeoUKOQKBE9A==,
       }
     peerDependencies:
       '@near-wallet-selector/modal-ui': ^8.9.7
@@ -12446,7 +12446,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
-  '@calimero-is-near/calimero-p2p-sdk@0.0.26(@near-wallet-selector/modal-ui@8.9.8(near-api-js@3.0.4))(@types/react@18.3.3)(bufferutil@4.0.8)(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(rollup@4.13.0)(typescript@5.4.5)':
+  '@calimero-is-near/calimero-p2p-sdk@0.0.27(@near-wallet-selector/modal-ui@8.9.8(near-api-js@3.0.4))(@types/react@18.3.3)(bufferutil@4.0.8)(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(bufferutil@4.0.8)(react@18.3.1))(rollup@4.13.0)(typescript@5.4.5)':
     dependencies:
       '@libp2p/crypto': 4.1.2
       '@libp2p/interface': 1.4.0

--- a/src/api/dataSource/NodeDataSource.ts
+++ b/src/api/dataSource/NodeDataSource.ts
@@ -2,6 +2,7 @@ import { Header, createAuthHeader } from '@calimero-is-near/calimero-p2p-sdk';
 import { getAppEndpointKey } from '../../utils/storage';
 import { HttpClient } from '../httpClient';
 import { ApiResponse, ResponseData } from '../response';
+import { NodeApi } from '../nodeApi';
 
 export enum Network {
   NEAR = 'NEAR',
@@ -115,7 +116,7 @@ export interface DeleteContextResponse {
   isDeleted: boolean;
 }
 
-export class NodeDataSource {
+export class NodeDataSource implements NodeApi {
   private client: HttpClient;
 
   constructor(client: HttpClient) {

--- a/src/api/nodeApi.ts
+++ b/src/api/nodeApi.ts
@@ -17,7 +17,6 @@ export interface NodeApi {
   getInstalledApplications(): ApiResponse<ListApplicationsResponse>;
   getContexts(): ApiResponse<ContextList>;
   getContext(contextId: string): ApiResponse<ApiContext>;
-  getContext(contextId: string): ApiResponse<Context>;
   getContextClientKeys(contextId: string): ApiResponse<ContextClientKeysList>;
   getContextUsers(contextId: string): ApiResponse<ContextUsersList>;
   deleteContext(contextId: string): ApiResponse<DeleteContextResponse>;

--- a/src/api/nodeApi.ts
+++ b/src/api/nodeApi.ts
@@ -1,3 +1,4 @@
+import { ApiResponse } from '@calimero-is-near/calimero-p2p-sdk';
 import {
   ContextStorage,
   Context,
@@ -11,7 +12,6 @@ import {
   DidResponse,
   DeleteContextResponse,
 } from './dataSource/NodeDataSource';
-import { ApiResponse } from './response';
 
 export interface NodeApi {
   getInstalledApplications(): ApiResponse<ListApplicationsResponse>;

--- a/src/components/context/ContextTable.tsx
+++ b/src/components/context/ContextTable.tsx
@@ -6,11 +6,11 @@ import OptionsHeader, { TableOptions } from '../common/OptionsHeader';
 import ListTable from '../common/ListTable';
 import rowItem from './RowItem';
 import invitationRowItem from './InvitationRowItem';
-import { Options } from '../../constants/ContextConstants';
+import { ContextOptions } from '../../constants/ContextConstants';
 import StatusModal, { ModalContent } from '../common/StatusModal';
 import ActionDialog from '../common/ActionDialog';
 import { ContextsList } from '../../api/dataSource/NodeDataSource';
-import { ContextObject, Invitation } from '../../pages/Contexts';
+import { ContextObject, Invitation } from '../../types/context';
 
 const FlexWrapper = styled.div`
   flex: 1;
@@ -77,7 +77,7 @@ export default function ContextTable({
           currentOption={currentOption}
           setCurrentOption={setCurrentOption}
         />
-        {currentOption === Options.JOINED ? (
+        {currentOption === ContextOptions.JOINED ? (
           <ListTable<ContextObject>
             listHeaderItems={['ID', 'INSTALLED APPLICATION']}
             numOfColumns={2}

--- a/src/components/context/RowItem.tsx
+++ b/src/components/context/RowItem.tsx
@@ -68,7 +68,9 @@ export default function rowItem(
       <a href={`contexts/${item.id}`} className="row-item id">
         {item.id}
       </a>
-      <div className="row-item name">{item.name}</div>
+      <div className="row-item name">
+        {item.name ?? 'Development application'}
+      </div>
       <div className="menu-dropdown">
         <MenuIconDropdown
           options={[

--- a/src/components/context/contextDetails/ContextTable.tsx
+++ b/src/components/context/contextDetails/ContextTable.tsx
@@ -8,75 +8,72 @@ import clientKeyRowItem from './ClientKeyRowItem';
 import userRowItem from './UserRowItem';
 import { DetailsOptions } from '../../../constants/ContextConstants';
 import DetailsCard from './DetailsCard';
-import { ApiResponse, ContextObject } from '../../../pages/ContextDetails';
 import {
   ClientKey,
   ContextStorage,
   User,
 } from '../../../api/dataSource/NodeDataSource';
+import { ContextDetails } from '../../../types/context';
 
 const FlexWrapper = styled.div`
   flex: 1;
 `;
 
 interface ContextTableProps {
-  contextDetails: ApiResponse<ContextObject>;
-  contextClientKeys: ApiResponse<ClientKey[]>;
-  contextUsers: ApiResponse<User[]>;
-  contextStorage: ApiResponse<ContextStorage>;
+  contextDetails: ContextDetails;
+  contextDetailsError: string | null;
+  contextClientKeys: ClientKey[];
+  contextClientKeysError: string | null;
+  contextUsers: User[];
+  contextUsersError: string | null;
+  contextStorage: ContextStorage;
+  contextStorageError: string | null;
   navigateToContextList: () => void;
   currentOption: string;
   setCurrentOption: (option: string) => void;
   tableOptions: TableOptions[];
 }
 
-export default function ContextTable({
-  contextDetails,
-  contextClientKeys,
-  contextUsers,
-  contextStorage,
-  navigateToContextList,
-  currentOption,
-  setCurrentOption,
-  tableOptions,
-}: ContextTableProps) {
+export default function ContextTable(props: ContextTableProps) {
   const t = translations.contextPage.contextDetails;
 
   return (
     <ContentCard
       headerBackText={t.title}
-      headerOnBackClick={navigateToContextList}
+      headerOnBackClick={props.navigateToContextList}
     >
       <FlexWrapper>
         <OptionsHeader
-          tableOptions={tableOptions}
+          tableOptions={props.tableOptions}
           showOptionsCount={true}
-          currentOption={currentOption}
-          setCurrentOption={setCurrentOption}
+          currentOption={props.currentOption}
+          setCurrentOption={props.setCurrentOption}
         />
-        {currentOption === DetailsOptions.DETAILS && (
+        {props.currentOption === DetailsOptions.DETAILS && (
           <DetailsCard
-            details={contextDetails}
-            contextStorage={contextStorage}
+            details={props.contextDetails}
+            detailsErrror={props.contextDetailsError}
+            contextStorage={props.contextStorage}
+            contextStorageError={props.contextStorageError}
           />
         )}
-        {currentOption === DetailsOptions.CLIENT_KEYS && (
+        {props.currentOption === DetailsOptions.CLIENT_KEYS && (
           <ListTable<ClientKey>
             listDescription={t.clientKeysListDescription}
             numOfColumns={3}
             listHeaderItems={['TYPE', 'ADDED', 'PUBLIC KEY']}
-            listItems={contextClientKeys.data || []}
-            error={contextClientKeys.error ?? ''}
+            listItems={props.contextClientKeys || []}
+            error={props.contextClientKeysError ?? ''}
             rowItem={clientKeyRowItem}
             roundTopItem={true}
             noItemsText={t.noClientKeysText}
           />
         )}
-        {currentOption === DetailsOptions.USERS && (
+        {props.currentOption === DetailsOptions.USERS && (
           <ListTable<User>
             numOfColumns={2}
-            listItems={contextUsers.data || []}
-            error={contextUsers.error ?? ''}
+            listItems={props.contextUsers || []}
+            error={props.contextUsersError ?? ''}
             listHeaderItems={['USER ID', 'JOINED']}
             rowItem={userRowItem}
             roundTopItem={true}

--- a/src/components/context/contextDetails/DetailsCard.tsx
+++ b/src/components/context/contextDetails/DetailsCard.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 import LoaderSpinner from '../../common/LoaderSpinner';
 import translations from '../../../constants/en.global.json';
-import { ApiResponse, ContextObject } from '../../../pages/ContextDetails';
 import { convertBytes } from '../../../utils/displayFunctions';
 import { ContextStorage } from '../../../api/dataSource/NodeDataSource';
+import { ContextDetails } from '../../../types/context';
 
 const DetailsCardWrapper = styled.div`
   padding-left: 1rem;
@@ -51,66 +51,71 @@ const DetailsCardWrapper = styled.div`
 `;
 
 interface DetailsCardProps {
-  details: ApiResponse<ContextObject>;
-  contextStorage: ApiResponse<ContextStorage>;
+  details: ContextDetails;
+  detailsErrror: string | null;
+  contextStorage: ContextStorage;
+  contextStorageError: string | null;
 }
 
-export default function DetailsCard({
-  details,
-  contextStorage,
-}: DetailsCardProps) {
+export default function DetailsCard(props: DetailsCardProps) {
   const t = translations.contextPage.contextDetails;
 
-  if (!details) {
+  if (!props.details) {
     return <LoaderSpinner />;
   }
 
   return (
     <DetailsCardWrapper>
-      {details.data ? (
+      {props.details ? (
         <div className="container">
           <div className="context-id">
             {t.labelIdText}
-            {details.data.contextId}
+            {props.details.contextId}
           </div>
           <div className="highlight title inter-mid">{t.titleApps}</div>
           <div className="item">
             {t.labelNameText}
-            <span className="highlight">{details.data.name}</span>
+            <span className="highlight">
+              {props.details.package?.name ?? '-'}
+            </span>
           </div>
           <div className="item">
             {t.labelOwnerText}
-            <span className="highlight">{details.data.owner}</span>
+            <span className="highlight">
+              {props.details.package?.owner ?? '-'}
+            </span>
           </div>
           <div className="item">
             {t.labelDescriptionText}
-            {details.data.description}
+            {props.details.package?.description ?? '-'}
           </div>
           <div className="item">
             {t.labelRepositoryText}
-            {details.data.repository}
+            {props.details.package?.repository ?? '-'}
           </div>
           <div className="item">
             {t.lableVersionText}
-            <span className="highlight">{details.data.version}</span>
+            <span className="highlight">
+              {props.details.release?.version ?? '-'}
+            </span>
           </div>
           <div className="item">
             {t.labelAppId}
-            {details.data.applicationId}
+            {props.details.applicationId}
           </div>
           <div className="highlight title">{t.titleStorage}</div>
           <div className="item">
             {t.labelStorageText}
             <span className="highlight">
-              {contextStorage.data
-                ? convertBytes(contextStorage.data.sizeInBytes)
-                : contextStorage.error}
+              {props.contextStorage
+                ? convertBytes(props.contextStorage.sizeInBytes)
+                : props.contextStorageError}
             </span>
           </div>
         </div>
       ) : (
         <div className="container-full">
-          <div className="item">{details.error}</div>
+          <div className="item">{props.details}</div>
         </div>
       )}
     </DetailsCardWrapper>

--- a/src/components/protectedRoutes/ProtectedRoute.tsx
+++ b/src/components/protectedRoutes/ProtectedRoute.tsx
@@ -11,12 +11,16 @@ export default function ProtectedRoute() {
 
   useEffect(() => {
     const isAuthPath = pathname.startsWith('/auth');
-    if (isAuthorized && clientKey) {
-      if (isAuthPath) {
+    if (isAuthPath) {
+      if (isAuthorized && clientKey) {
+        //navigate to home page after auth is successfull
         navigate('/identity');
       }
     } else {
-      navigate('/auth');
+      if (!(isAuthorized && clientKey)) {
+        //show auth if not authorized
+        navigate('/auth');
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthorized, clientKey]);

--- a/src/constants/ContextConstants.ts
+++ b/src/constants/ContextConstants.ts
@@ -3,7 +3,7 @@ export enum Content {
   START_NEW_CONTEXT = 'START_NEW_CONTEXT',
 }
 
-export enum Options {
+export enum ContextOptions {
   JOINED = 'JOINED',
   INVITED = 'INVITED',
 }

--- a/src/hooks/useNear.ts
+++ b/src/hooks/useNear.ts
@@ -26,24 +26,30 @@ export function useRPC() {
     return JSON.parse(Buffer.from(rawResult.result).toString());
   };
 
-  const getPackage = async (id: string): Promise<Package> => {
-    const provider = new nearAPI.providers.JsonRpcProvider({
-      url: JSON_RPC_ENDPOINT,
-    });
+  const getPackage = async (id: string): Promise<Package | null> => {
+    try {
+      const provider = new nearAPI.providers.JsonRpcProvider({
+        url: JSON_RPC_ENDPOINT,
+      });
 
-    const rawResult = await provider.query({
-      request_type: 'call_function',
-      account_id: 'calimero-package-manager.testnet',
-      method_name: 'get_package',
-      args_base64: btoa(
-        JSON.stringify({
-          id,
-        }),
-      ),
-      finality: 'final',
-    });
-    // @ts-expect-error: Property 'result' does not exist on type 'QueryResponseKind'
-    return JSON.parse(Buffer.from(rawResult.result).toString());
+      const rawResult = await provider.query({
+        request_type: 'call_function',
+        account_id: 'calimero-package-manager.testnet',
+        method_name: 'get_package',
+        args_base64: btoa(
+          JSON.stringify({
+            id,
+          }),
+        ),
+        finality: 'final',
+      });
+      // @ts-expect-error: Property 'result' does not exist on type 'QueryResponseKind'
+      return JSON.parse(Buffer.from(rawResult.result).toString());
+    } catch (e) {
+      //If there is no package available, there is high possibility that context contains local wasm for development
+      console.log('Error getting package', e);
+      return null;
+    }
   };
 
   const getReleases = async (id: string): Promise<Release[]> => {

--- a/src/pages/AddMetamaskRootKey.tsx
+++ b/src/pages/AddMetamaskRootKey.tsx
@@ -4,7 +4,7 @@ import { MetamaskWrapper } from '@calimero-is-near/calimero-p2p-sdk';
 import ContentWrapper from '../components/login/ContentWrapper';
 import { getNodeUrl } from '../utils/node';
 
-export default function AddMetamaskRootKey() {
+export default function AddMetamaskRootKeyPage() {
   const navigate = useNavigate();
   return (
     <ContentWrapper>

--- a/src/pages/AddNearRootKey.tsx
+++ b/src/pages/AddNearRootKey.tsx
@@ -7,7 +7,7 @@ import ContentWrapper from '../components/login/ContentWrapper';
 import '@near-wallet-selector/modal-ui/styles.css';
 import { getNearEnvironment, getNodeUrl } from '../utils/node';
 
-export default function AddNearRootKey() {
+export default function AddNearRootKeyPage() {
   const navigate = useNavigate();
 
   return (

--- a/src/pages/AddRelease.tsx
+++ b/src/pages/AddRelease.tsx
@@ -23,7 +23,7 @@ import { getNearEnvironment } from '../utils/node';
 
 const BLOBBY_IPFS = 'https://blobby-public.euw3.prod.gcp.calimero.network';
 
-export default function AddRelease() {
+export default function AddReleasePage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -71,10 +71,12 @@ export default function AddRelease() {
     };
     const fetchPackageInfo = async () => {
       if (id) {
-        const packageInfo = await getPackage(id);
-        setApplicationInformation(packageInfo);
-        const latestRelease = await getLatestRelease(id);
-        setLatestRelease(latestRelease?.version!);
+        const packageInfo: Package | null = await getPackage(id);
+        if (packageInfo) {
+          setApplicationInformation(packageInfo);
+          const latestRelease = await getLatestRelease(id);
+          setLatestRelease(latestRelease?.version!);
+        }
       }
     };
 

--- a/src/pages/AddRootKey.tsx
+++ b/src/pages/AddRootKey.tsx
@@ -3,7 +3,7 @@ import { LoginSelector } from '@calimero-is-near/calimero-p2p-sdk';
 import { useNavigate } from 'react-router-dom';
 import ContentWrapper from '../components/login/ContentWrapper';
 
-export default function AddRootKey() {
+export default function AddRootKeyPage() {
   const navigate = useNavigate();
   return (
     <ContentWrapper>

--- a/src/pages/ApplicationDetails.tsx
+++ b/src/pages/ApplicationDetails.tsx
@@ -13,7 +13,7 @@ export interface AppDetails {
   releases: Release[];
 }
 
-export default function ApplicationDetails() {
+export default function ApplicationDetailsPage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const { getPackage, getReleases } = useRPC();

--- a/src/pages/Authenticate.tsx
+++ b/src/pages/Authenticate.tsx
@@ -3,7 +3,7 @@ import { LoginSelector } from '@calimero-is-near/calimero-p2p-sdk';
 import { useNavigate } from 'react-router-dom';
 import ContentWrapper from '../components/login/ContentWrapper';
 
-export default function Authenticate() {
+export default function AuthenticatePage() {
   const navigate = useNavigate();
   return (
     <ContentWrapper>

--- a/src/pages/Contexts.tsx
+++ b/src/pages/Contexts.tsx
@@ -3,45 +3,39 @@ import { Navigation } from '../components/Navigation';
 import { FlexLayout } from '../components/layout/FlexLayout';
 import PageContentWrapper from '../components/common/PageContentWrapper';
 import ContextTable from '../components/context/ContextTable';
-import { Options } from '../constants/ContextConstants';
+import { ContextOptions } from '../constants/ContextConstants';
 import { useNavigate } from 'react-router-dom';
 import { useRPC } from '../hooks/useNear';
 import apiClient from '../api/index';
-import { Context, ContextsList } from '../api/dataSource/NodeDataSource';
+import {
+  Context,
+  ContextList,
+  ContextsList,
+} from '../api/dataSource/NodeDataSource';
 import { ModalContent } from '../components/common/StatusModal';
 import { TableOptions } from '../components/common/OptionsHeader';
-
-export interface Invitation {
-  id: string;
-  invitedOn: string;
-}
-
-export interface ContextObject {
-  id: string;
-  applicationId: string;
-  name: string;
-  description: string;
-  repository: string;
-  owner: string;
-}
+import { ResponseData } from '../api/response';
+import { ContextObject } from '../types/context';
 
 const initialOptions = [
   {
     name: 'Joined',
-    id: Options.JOINED,
+    id: ContextOptions.JOINED,
     count: 0,
-  },
+  } as TableOptions,
   {
     name: 'Invited',
-    id: Options.INVITED,
+    id: ContextOptions.INVITED,
     count: 0,
-  },
+  } as TableOptions,
 ];
 
-export default function Contexts() {
+export default function ContextsPage() {
   const navigate = useNavigate();
   const { getPackage } = useRPC();
-  const [currentOption, setCurrentOption] = useState<string>(Options.JOINED);
+  const [currentOption, setCurrentOption] = useState<string>(
+    ContextOptions.JOINED,
+  );
   const [tableOptions, setTableOptions] =
     useState<TableOptions[]>(initialOptions);
   const [errorMessage, setErrorMessage] = useState('');
@@ -65,14 +59,14 @@ export default function Contexts() {
   const generateContextObjects = useCallback(
     async (contexts: Context[]): Promise<ContextObject[]> => {
       try {
-        const tempContextObjects = await Promise.all(
+        const tempContextObjects: ContextObject[] = await Promise.all(
           contexts.map(async (app: Context) => {
             const packageData = await getPackage(app.applicationId);
-            return {
-              ...packageData,
+            const contextObject: ContextObject = {
               id: app.id,
-              applicationId: packageData.id,
+              package: packageData,
             };
+            return contextObject;
           }),
         );
         return tempContextObjects;
@@ -86,7 +80,9 @@ export default function Contexts() {
 
   const fetchNodeContexts = useCallback(async () => {
     setErrorMessage('');
-    const fetchContextsResponse = await apiClient.node().getContexts();
+    const fetchContextsResponse: ResponseData<ContextList> = await apiClient
+      .node()
+      .getContexts();
     // TODO - fetch invitations
     if (fetchContextsResponse.error) {
       setErrorMessage(fetchContextsResponse.error.message);
@@ -105,13 +101,13 @@ export default function Contexts() {
       setTableOptions([
         {
           name: 'Joined',
-          id: Options.JOINED,
+          id: ContextOptions.JOINED,
           count: nodeContexts.contexts?.length ?? 0,
         },
         {
           name: 'Invited',
           // TODO - invitation count when api is ready
-          id: Options.INVITED,
+          id: ContextOptions.INVITED,
           count: 0,
         },
       ]);

--- a/src/pages/Export.tsx
+++ b/src/pages/Export.tsx
@@ -20,7 +20,7 @@ const ExportWrapper = styled.div`
   -moz-osx-font-smoothing: grayscale;
   font-smooth: never;
 `;
-export default function Export() {
+export default function ExportPage() {
   const t = translations.exportIdentityPage;
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [exportStatus, setExportStatus] = useState<ModalContentItem>({

--- a/src/pages/Identity.tsx
+++ b/src/pages/Identity.tsx
@@ -11,7 +11,7 @@ export interface RootKey {
   signingKey: string;
 }
 
-export default function Identity() {
+export default function IdentityPage() {
   const navigate = useNavigate();
   const [errorMessage, setErrorMessage] = useState('');
   const [rootKeys, setRootKeys] = useState<RootKeyObject[]>([]);

--- a/src/pages/Metamask.tsx
+++ b/src/pages/Metamask.tsx
@@ -4,7 +4,7 @@ import { MetamaskWrapper } from '@calimero-is-near/calimero-p2p-sdk';
 import ContentWrapper from '../components/login/ContentWrapper';
 import { getNodeUrl } from '../utils/node';
 
-export default function Metamask() {
+export default function MetamaskPage() {
   const navigate = useNavigate();
   return (
     <ContentWrapper>

--- a/src/pages/Near.tsx
+++ b/src/pages/Near.tsx
@@ -7,7 +7,7 @@ import ContentWrapper from '../components/login/ContentWrapper';
 import '@near-wallet-selector/modal-ui/styles.css';
 import { getNearEnvironment, getNodeUrl } from '../utils/node';
 
-export default function Near() {
+export default function NearPage() {
   const navigate = useNavigate();
 
   return (

--- a/src/pages/PublishApplication.tsx
+++ b/src/pages/PublishApplication.tsx
@@ -40,7 +40,7 @@ export interface DeployStatus {
   error: boolean;
 }
 
-export default function PublishApplication() {
+export default function PublishApplicationPage() {
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const { getPackages } = useRPC();

--- a/src/pages/StartContext.tsx
+++ b/src/pages/StartContext.tsx
@@ -14,7 +14,7 @@ export interface ContextApplication {
   version: string;
 }
 
-export default function StartContext() {
+export default function StartContextPage() {
   const t = translations.startContextPage;
   const navigate = useNavigate();
   const [application, setApplication] = useState<ContextApplication>({

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,0 +1,18 @@
+import { Package, Release } from '../pages/Applications';
+
+export interface ContextDetails {
+  contextId: string;
+  applicationId: string;
+  package: Package | null;
+  release: Release | null;
+}
+
+export interface Invitation {
+  id: string;
+  invitedOn: string;
+}
+
+export interface ContextObject {
+  id: string;
+  package: Package | null;
+}


### PR DESCRIPTION
- Enable preview of context with the development application.
- Refactor code little bit so it is easier to follow types
     - getPackage can now return `null` if package is not found. That is the case when context contains dev app which is not published
     -  use Page suffix for pages
     - remove two ContextObject types. One is now ContextDetails
     - remove `ApiResponse` from components and use separate error and data objects
     - add type checks 
     - rename some types to better describe purpose

![Screenshot 2024-07-10 at 00 21 00](https://github.com/calimero-network/admin-dashboard/assets/12198572/052ee20d-4ff3-4ea3-9f43-8c4608d0d4f2)
