### PR TITLE
feat: pass application ipfs path to the node api

### DIFF
--- a/src/api/dataSource/NodeDataSource.ts
+++ b/src/api/dataSource/NodeDataSource.ts
@@ -292,6 +292,7 @@ export class NodeDataSource implements NodeApi {
   async installApplication(
     selectedPackage: string,
     selectedVersion: string,
+    ipfsPath: string,
   ): ApiResponse<boolean> {
     try {
       const headers: Header | null = await createAuthHeader(
@@ -305,6 +306,7 @@ export class NodeDataSource implements NodeApi {
         {
           application: selectedPackage,
           version: selectedVersion,
+          ipfsPath,
         },
         headers ?? {},
       );

--- a/src/api/dataSource/NodeDataSource.ts
+++ b/src/api/dataSource/NodeDataSource.ts
@@ -306,7 +306,7 @@ export class NodeDataSource implements NodeApi {
         {
           application: selectedPackage,
           version: selectedVersion,
-          ipfsPath,
+          path: ipfsPath,
         },
         headers ?? {},
       );

--- a/src/api/dataSource/NodeDataSource.ts
+++ b/src/api/dataSource/NodeDataSource.ts
@@ -307,7 +307,7 @@ export class NodeDataSource implements NodeApi {
         {
           application: selectedPackage,
           version: selectedVersion,
-          path: ipfsPath,
+          url: ipfsPath,
           hash,
         },
         headers ?? {},

--- a/src/api/dataSource/NodeDataSource.ts
+++ b/src/api/dataSource/NodeDataSource.ts
@@ -293,6 +293,7 @@ export class NodeDataSource implements NodeApi {
     selectedPackage: string,
     selectedVersion: string,
     ipfsPath: string,
+    hash: string,
   ): ApiResponse<boolean> {
     try {
       const headers: Header | null = await createAuthHeader(
@@ -307,6 +308,7 @@ export class NodeDataSource implements NodeApi {
           application: selectedPackage,
           version: selectedVersion,
           path: ipfsPath,
+          hash,
         },
         headers ?? {},
       );

--- a/src/api/nodeApi.ts
+++ b/src/api/nodeApi.ts
@@ -32,5 +32,6 @@ export interface NodeApi {
     selectedPackage: string,
     selectedVersion: string,
     ipfsPath: string,
+    hash: string,
   ): ApiResponse<boolean>;
 }

--- a/src/api/nodeApi.ts
+++ b/src/api/nodeApi.ts
@@ -31,5 +31,6 @@ export interface NodeApi {
   installApplication(
     selectedPackage: string,
     selectedVersion: string,
+    ipfsPath: string,
   ): ApiResponse<boolean>;
 }

--- a/src/components/context/startContext/ApplicationsPopup.tsx
+++ b/src/components/context/startContext/ApplicationsPopup.tsx
@@ -87,8 +87,9 @@ export default function ApplicationsPopup({
     const release = await getLatestRelease(applicationId);
     setApplication({
       appId: applicationId,
-      name: application.name,
+      name: application?.name ?? '',
       version: release?.version ?? '',
+      path: release?.path ?? '',
     });
     closeModal();
   };

--- a/src/components/context/startContext/ApplicationsPopup.tsx
+++ b/src/components/context/startContext/ApplicationsPopup.tsx
@@ -90,6 +90,7 @@ export default function ApplicationsPopup({
       name: application?.name ?? '',
       version: release?.version ?? '',
       path: release?.path ?? '',
+      hash: release?.hash ?? '',
     });
     closeModal();
   };

--- a/src/components/context/startContext/StartContextCard.tsx
+++ b/src/components/context/startContext/StartContextCard.tsx
@@ -222,6 +222,7 @@ export default function StartContextCard({
                   appId: '',
                   name: '',
                   version: '',
+                  path: '',
                 })
               }
             />

--- a/src/components/context/startContext/StartContextCard.tsx
+++ b/src/components/context/startContext/StartContextCard.tsx
@@ -223,6 +223,7 @@ export default function StartContextCard({
                   name: '',
                   version: '',
                   path: '',
+                  hash: '',
                 })
               }
             />

--- a/src/pages/StartContext.tsx
+++ b/src/pages/StartContext.tsx
@@ -12,6 +12,7 @@ export interface ContextApplication {
   appId: string;
   name: string;
   version: string;
+  path: string;
 }
 
 export default function StartContextPage() {
@@ -21,6 +22,7 @@ export default function StartContextPage() {
     appId: '',
     name: '',
     version: '',
+    path: '',
   });
   const [isArgsChecked, setIsArgsChecked] = useState(false);
   const [methodName, setMethodName] = useState('');
@@ -69,9 +71,10 @@ export default function StartContextPage() {
     if (!application.appId || !application.version) {
       return false;
     }
+
     const response = await apiClient
       .node()
-      .installApplication(application.appId, application.version);
+      .installApplication(application.appId, application.version, application.path);
     if (response.error) {
       setStartContextStatus({
         title: t.failInstallTitle,

--- a/src/pages/StartContext.tsx
+++ b/src/pages/StartContext.tsx
@@ -13,6 +13,7 @@ export interface ContextApplication {
   name: string;
   version: string;
   path: string;
+  hash: string;
 }
 
 export default function StartContextPage() {
@@ -23,6 +24,7 @@ export default function StartContextPage() {
     name: '',
     version: '',
     path: '',
+    hash: '',
   });
   const [isArgsChecked, setIsArgsChecked] = useState(false);
   const [methodName, setMethodName] = useState('');
@@ -78,6 +80,7 @@ export default function StartContextPage() {
         application.appId,
         application.version,
         application.path,
+        application.hash,
       );
     if (response.error) {
       setStartContextStatus({

--- a/src/pages/StartContext.tsx
+++ b/src/pages/StartContext.tsx
@@ -74,7 +74,11 @@ export default function StartContextPage() {
 
     const response = await apiClient
       .node()
-      .installApplication(application.appId, application.version, application.path);
+      .installApplication(
+        application.appId,
+        application.version,
+        application.path,
+      );
     if (response.error) {
       setStartContextStatus({
         title: t.failInstallTitle,


### PR DESCRIPTION
# feat: pass application ipfs path to the node api

## Summary:
This is the UI update for [this](https://github.com/calimero-network/core/issues/477) issue regarding client side app installation. 

The node should not have to know where the application binary is hosted (testnet/mainnet) so the path is queried from the contract on the client side.