### PR TITLE
feat: add copy to clipboard button for hash + url

### DIFF
--- a/src/components/applications/details/ReleaseRowItem.tsx
+++ b/src/components/applications/details/ReleaseRowItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { truncateHash } from '../../../utils/displayFunctions';
 import { Release } from '../../../pages/Applications';
+import { ClipboardDocumentIcon } from '@heroicons/react/24/solid';
 
 export interface RowItemProps {
   $hasBorders: boolean;
@@ -45,6 +46,16 @@ export const RowItem = styled.div<RowItemProps>`
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  .copy-icon {
+    height: 1.5rem;
+    width: 1.5rem;
+    color: #9c9da3;
+    cursor: pointer;
+  }
+  .copy-icon:hover {
+  color: #fff;
+  }
 `;
 
 export default function releaseRowItem(
@@ -52,15 +63,26 @@ export default function releaseRowItem(
   id: number,
   count: number,
 ): JSX.Element {
+
+  const copyToClippboard = (text: string) => {
+    navigator.clipboard.writeText(text).then(() => {
+      console.log('Text copied to clipboard');
+    }).catch(err => {
+      console.error('Failed to copy text to clipboard: ', err);
+    });
+  }
+
   return (
     <RowItem key={item.hash} $hasBorders={id === count}>
       <div className="row-item name">{item.version}</div>
       <div className="row-item read">
+        <ClipboardDocumentIcon className="copy-icon" onClick={() => copyToClippboard(item.path)}/>
         <span className="long-text">{item.path.substring(0, 20)}...</span>
       </div>
       <div className="row-item read">
         <span className="long-text">{item.notes}</span>
       </div>
+      <ClipboardDocumentIcon className="copy-icon" onClick={() => copyToClippboard(item.hash)}/>
       <div className="row-item read">{truncateHash(item.hash)}</div>
     </RowItem>
   );

--- a/src/components/applications/details/ReleaseRowItem.tsx
+++ b/src/components/applications/details/ReleaseRowItem.tsx
@@ -54,7 +54,7 @@ export const RowItem = styled.div<RowItemProps>`
     cursor: pointer;
   }
   .copy-icon:hover {
-  color: #fff;
+    color: #fff;
   }
 `;
 
@@ -63,26 +63,34 @@ export default function releaseRowItem(
   id: number,
   count: number,
 ): JSX.Element {
-
   const copyToClippboard = (text: string) => {
-    navigator.clipboard.writeText(text).then(() => {
-      console.log('Text copied to clipboard');
-    }).catch(err => {
-      console.error('Failed to copy text to clipboard: ', err);
-    });
-  }
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        console.log('Text copied to clipboard');
+      })
+      .catch((err) => {
+        console.error('Failed to copy text to clipboard: ', err);
+      });
+  };
 
   return (
     <RowItem key={item.hash} $hasBorders={id === count}>
       <div className="row-item name">{item.version}</div>
       <div className="row-item read">
-        <ClipboardDocumentIcon className="copy-icon" onClick={() => copyToClippboard(item.path)}/>
+        <ClipboardDocumentIcon
+          className="copy-icon"
+          onClick={() => copyToClippboard(item.path)}
+        />
         <span className="long-text">{item.path.substring(0, 20)}...</span>
       </div>
       <div className="row-item read">
         <span className="long-text">{item.notes}</span>
       </div>
-      <ClipboardDocumentIcon className="copy-icon" onClick={() => copyToClippboard(item.hash)}/>
+      <ClipboardDocumentIcon
+        className="copy-icon"
+        onClick={() => copyToClippboard(item.hash)}
+      />
       <div className="row-item read">{truncateHash(item.hash)}</div>
     </RowItem>
   );


### PR DESCRIPTION
# feat: add copy to clipboard button for hash + url

## Summary:
title

#tests:

https://github.com/user-attachments/assets/a7248106-b018-40f3-adba-db1e7f4da52e

