### PR TITLE
fix: form gets cleaned after account is connected

### DIFF
--- a/src/components/publishApplication/PublishApplicationTable.tsx
+++ b/src/components/publishApplication/PublishApplicationTable.tsx
@@ -16,6 +16,7 @@ const FlexWrapper = styled.div`
   .button-wrapper {
     padding: 1.5rem 1rem 2.563rem;
   }
+  padding: 1rem;
 `;
 
 interface PublishApplicationTableProps {
@@ -68,38 +69,43 @@ export default function PublishApplicationTable({
         modalContent={deployStatus}
       />
       <FlexWrapper>
-        <AddPackageForm
-          packageInfo={packageInfo}
-          setPackageInfo={setPackageInfo}
-        />
-        <AddReleaseForm
-          handleFileChange={handleFileChange}
-          fileHash={fileHash}
-          releaseInfo={releaseInfo}
-          setReleaseInfo={setReleaseInfo}
-          fileInputRef={fileInputRef}
-        />
         <ConnectWalletAccountCard onClick={addWalletAccount} />
-        <div className="button-wrapper">
-          <Button
-            text={t.buttonText}
-            width="100%"
-            onClick={publishApplication}
-            isDisabled={
-              !(
-                deployerAccount &&
-                packageInfo.name &&
-                packageInfo.description &&
-                packageInfo.repository &&
-                releaseInfo.version &&
-                releaseInfo.notes &&
-                releaseInfo.path &&
-                releaseInfo.hash
-              )
-            }
-            isLoading={isLoading}
-          />
-        </div>
+
+        {deployerAccount && (
+          <>
+            <AddPackageForm
+              packageInfo={packageInfo}
+              setPackageInfo={setPackageInfo}
+            />
+            <AddReleaseForm
+              handleFileChange={handleFileChange}
+              fileHash={fileHash}
+              releaseInfo={releaseInfo}
+              setReleaseInfo={setReleaseInfo}
+              fileInputRef={fileInputRef}
+            />
+            <div className="button-wrapper">
+              <Button
+                text={t.buttonText}
+                width="100%"
+                onClick={publishApplication}
+                isDisabled={
+                  !(
+                    deployerAccount &&
+                    packageInfo.name &&
+                    packageInfo.description &&
+                    packageInfo.repository &&
+                    releaseInfo.version &&
+                    releaseInfo.notes &&
+                    releaseInfo.path &&
+                    releaseInfo.hash
+                  )
+                }
+                isLoading={isLoading}
+              />
+            </div>
+          </>
+        )}
       </FlexWrapper>
     </ContentCard>
   );

--- a/src/pages/PublishApplication.tsx
+++ b/src/pages/PublishApplication.tsx
@@ -4,6 +4,7 @@ import { FlexLayout } from '../components/layout/FlexLayout';
 import {
   Account,
   BrowserWallet,
+  NetworkId,
   setupWalletSelector,
 } from '@near-wallet-selector/core';
 import { setupMyNearWallet } from '@near-wallet-selector/my-near-wallet';
@@ -72,7 +73,8 @@ export default function PublishApplicationPage() {
     (async () => {
       setPackages(await getPackages());
     })();
-  }, [getPackages, ipfsPath]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ipfsPath]);
 
   useEffect(() => {
     setReleaseInfo((prevState) => ({
@@ -99,7 +101,7 @@ export default function PublishApplicationPage() {
 
   const addWalletAccount = async () => {
     const selector = await setupWalletSelector({
-      network: getNearEnvironment(),
+      network: getNearEnvironment() as NetworkId,
       modules: [setupMyNearWallet()],
     });
     const wallet: BrowserWallet = await selector.wallet('my-near-wallet');


### PR DESCRIPTION
Initially select account was the last item. By logging in wallet and returning back, all data was lost. 

Now: it is the first piece, and then on reload, account is there and user can fill other parts.

<img width="1032" alt="Screenshot 2024-08-21 at 21 12 27" src="https://github.com/user-attachments/assets/1942e016-1025-4412-a07f-d131dc69f98a">

