### PR TITLE
feat(CI): release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,91 @@
+name: Build and Release Project
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  build_and_push:
+    if: github.event.pull_request.merged == true || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build app
+        run: pnpm build
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Read version from package.json
+        id: get_version
+        run: |
+          VERSION=$(jq -r .version package.json)
+          echo "version=$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Set up Git user
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+      - name: Push build folder to build branch
+        run: |
+          mkdir temp-deploy
+          cp -r build temp-deploy/
+
+          cd temp-deploy
+          git init
+          git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          
+          git fetch origin
+
+          git checkout build || git checkout -b build
+
+          git add .
+          git commit -m "Deploy build folder from commit $GITHUB_SHA"
+
+          VERSION="v${{ steps.get_version.outputs.version }}"
+
+          # Delete local tag if exists
+          git tag -d $VERSION 2>/dev/null || true
+
+          # Delete remote tag if exists
+          git push --delete origin $VERSION 2>/dev/null || true
+
+          git tag $VERSION
+          git push --force origin build
+          git push origin $VERSION
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.get_version.outputs.version }}
+          name: Release v${{ steps.get_version.outputs.version }}
+          target_commitish: build
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# feat(CI): release workflow

## Description
On each merge to master build project and copy build folder to build branch and create new release. Version (tag) of release will be fetched from package.json on project (e.g. 1.0.0 -> Release v1.0.0)

## Test plan
Tested on private repo 
<img width="1245" alt="Screenshot 2025-05-13 at 15 41 09" src="https://github.com/user-attachments/assets/2c6baa64-ccf1-4c05-a774-b7151991456a" />


**NOTE** : This "build folder" in release will be used for core repository