### PR TITLE
feat: add node url from query

### DIFF
--- a/src/pages/setup/index.tsx
+++ b/src/pages/setup/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { clearStorage, setAppEndpointKey } from '../../utils/storage';
 import ContentWrapper from '../../components/login/ContentWrapper';
 import { SetupModal } from '../../components/setup/SetupModal';
@@ -7,10 +7,16 @@ import { getNodeUrl } from '../../utils/node';
 
 export default function SetupPage() {
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     clearStorage();
-  }, []);
+    const params = new URLSearchParams(location.search);
+    const nodeUrl = params.get('node-url');
+    if (nodeUrl) {
+      setAppEndpointKey(nodeUrl);
+    }
+  }, [location.search]);
 
   return (
     <ContentWrapper>


### PR DESCRIPTION
# feat: add node url from query

## Description
Read node url from query and set it in local storage.
This feature is connected with Demo Dashboard where user will be able to navigate to admin dashboard with node url set automatically. 