### PR TITLE
feat: replace NEAR apps registry

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -36,7 +36,7 @@
       })(window.location);
     </script>
     <!-- End Single Page Apps for GitHub Pages -->
-    <script type="module" crossorigin src="/admin-dashboard/assets/main-ytwZVN2B.js"></script>
+    <script type="module" crossorigin src="/admin-dashboard/assets/main-BtjxaGiy.js"></script>
     <link rel="stylesheet" crossorigin href="/admin-dashboard/assets/main-CALIhgPD.css">
   </head>
   <body>

--- a/src/api/dataSource/NodeDataSource.ts
+++ b/src/api/dataSource/NodeDataSource.ts
@@ -65,7 +65,7 @@ export interface Context {
 
 export interface CreateContextResponse {
   contextId: string;
-  memberPublicKey: SigningKey;
+  memberPublicKey: string;
 }
 
 export interface GetContextsResponse {

--- a/src/components/applications/ApplicationsTable.tsx
+++ b/src/components/applications/ApplicationsTable.tsx
@@ -56,8 +56,8 @@ export default function ApplicationsTable(props: ApplicationsTableProps) {
   return (
     <ContentCard
       headerTitle={t.title}
-      headerOptionText={t.publishNewAppText}
-      headerOnOptionClick={props.navigateToPublishApp}
+      // headerOptionText={t.publishNewAppText}
+      // headerOnOptionClick={props.navigateToPublishApp}
       headerSecondOptionText={t.installNewAppText}
       headerOnSecondOptionClick={props.navigateToInstallApp}
     >

--- a/src/components/applications/InstallApplicationCard.tsx
+++ b/src/components/applications/InstallApplicationCard.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { XMarkIcon } from '@heroicons/react/24/solid';
 import { Application } from '../../pages/InstallApplication';
 import Button from '../common/Button';
-import ApplicationsPopup from '../context/startContext/ApplicationsPopup';
+// import ApplicationsPopup from '../context/startContext/ApplicationsPopup';
 import StatusModal, { ModalContent } from '../common/StatusModal';
 import translations from '../../constants/en.global.json';
 
@@ -156,8 +156,8 @@ export default function InstallApplicationCard({
   application,
   setApplication,
   installApplication,
-  showBrowseApplication,
-  setShowBrowseApplication,
+  // showBrowseApplication,
+  // setShowBrowseApplication,
   onUploadClick,
   isLoading,
   showStatusModal,
@@ -179,18 +179,18 @@ export default function InstallApplicationCard({
         closeModal={closeModal}
         modalContent={installAppStatus}
       />
-      {showBrowseApplication && (
+      {/* {showBrowseApplication && (
         <ApplicationsPopup
           show={showBrowseApplication}
           closeModal={() => setShowBrowseApplication(false)}
           setApplication={setApplication}
         />
-      )}
+      )} */}
       <div className="select-app-section">
         <div className="section-title">
           {application.appId
             ? t.selectedApplicationTitle
-            : t.selectApplicationTitle}
+            : t.selectApplicationTitleNew}
           {application.appId && (
             <XMarkIcon
               className="cancel-icon"
@@ -223,23 +223,25 @@ export default function InstallApplicationCard({
           </div>
         ) : (
           <div className="button-container">
-            <Button
+            {/* <Button
               text="Browse"
               width={'144px'}
               onClick={() => setShowBrowseApplication(true)}
-            />
-            <Button text="Upload" width={'144px'} onClick={onUploadClick} />
+            /> */}
+            <Button text="Browse" width={'144px'} onClick={onUploadClick} />
           </div>
         )}
       </div>
-      <div className="init-section">
-        <Button
-          text={t.installButtonText}
-          width={'144px'}
-          onClick={onStartContextClick}
-          isLoading={isLoading}
-        />
-      </div>
+      {application.appId && (
+        <div className="init-section">
+          <Button
+            text={t.installButtonText}
+            width={'144px'}
+            onClick={onStartContextClick}
+            isLoading={isLoading}
+          />
+        </div>
+      )}
     </Wrapper>
   );
 }

--- a/src/components/context/startContext/StartContextCard.tsx
+++ b/src/components/context/startContext/StartContextCard.tsx
@@ -6,6 +6,7 @@ import translations from '../../../constants/en.global.json';
 import StatusModal, { ModalContent } from '../../common/StatusModal';
 import { ContextApplication } from '../../../pages/StartContext';
 import { XMarkIcon } from '@heroicons/react/24/solid';
+import { InstalledApplication } from '../../../api/dataSource/NodeDataSource';
 
 const Wrapper = styled.div`
   display: flex;
@@ -137,7 +138,7 @@ const Wrapper = styled.div`
     }
   }
 
-  .protocol-input {
+  .protocol-input, .application-input {
     width: 100%;
     padding: 8px;
     border: 1px solid #ccc;
@@ -146,13 +147,13 @@ const Wrapper = styled.div`
     background-color: white;
   }
 
-  .protocol-input:focus {
+  .protocol-input:focus, .application-input:focus {
     outline: none;
     border-color: #007bff;
   }
 
   /* Optional: Style the dropdown arrow */
-  .protocol-input {
+  .protocol-input, .application-input {
     appearance: none;
     background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
     background-repeat: no-repeat;
@@ -165,8 +166,8 @@ const Wrapper = styled.div`
 `;
 
 interface StartContextCardProps {
-  application: ContextApplication;
-  setApplication: (application: ContextApplication) => void;
+  applicationId: string;
+  setApplicationId: (appId: string) => void;
   isArgsChecked: boolean;
   setIsArgsChecked: (checked: boolean) => void;
   argumentsJson: string;
@@ -180,11 +181,12 @@ interface StartContextCardProps {
   showStatusModal: boolean;
   closeModal: () => void;
   startContextStatus: ModalContent;
+  applications: InstalledApplication[];
 }
 
 export default function StartContextCard({
-  application,
-  setApplication,
+  applicationId,
+  setApplicationId,
   isArgsChecked,
   setIsArgsChecked,
   argumentsJson,
@@ -198,10 +200,11 @@ export default function StartContextCard({
   showStatusModal,
   closeModal,
   startContextStatus,
+  applications
 }: StartContextCardProps) {
   const t = translations.startContextPage;
   const onStartContextClick = async () => {
-    if (!application.appId) {
+    if (!applicationId) {
       return;
     } else if (isArgsChecked && !argumentsJson) {
       return;
@@ -210,14 +213,14 @@ export default function StartContextCard({
     }
   };
 
-  const formatArguments = () => {
-    try {
-      const formattedJson = JSON.stringify(JSON.parse(argumentsJson), null, 2);
-      setArgumentsJson(formattedJson);
-    } catch (error) {
-      console.log('error', error);
-    }
-  };
+  // const formatArguments = () => {
+  //   try {
+  //     const formattedJson = JSON.stringify(JSON.parse(argumentsJson), null, 2);
+  //     setArgumentsJson(formattedJson);
+  //   } catch (error) {
+  //     console.log('error', error);
+  //   }
+  // };
 
   return (
     <Wrapper>
@@ -226,19 +229,17 @@ export default function StartContextCard({
         closeModal={closeModal}
         modalContent={startContextStatus}
       />
-      {showBrowseApplication && (
+      {/* {showBrowseApplication && (
         <ApplicationsPopup
           show={showBrowseApplication}
           closeModal={() => setShowBrowseApplication(false)}
           setApplication={setApplication}
         />
-      )}
+      )} */}
       <div className="select-app-section">
         <div className="section-title">
-          {application.appId
-            ? t.selectedApplicationTitle
-            : t.selectApplicationTitle}
-          {application.appId && (
+          {t.selectApplicationTitleNew}
+          {/* {application.appId && (
             <XMarkIcon
               className="cancel-icon"
               onClick={() =>
@@ -251,9 +252,9 @@ export default function StartContextCard({
                 })
               }
             />
-          )}
+          )} */}
         </div>
-        {application.appId ? (
+        {/* {application.appId ? (
           <div className="selected-app">
             <p className="label">
               {t.idLabelText}
@@ -268,19 +269,19 @@ export default function StartContextCard({
               <span className="value">{application.version}</span>
             </p>
           </div>
-        ) : (
-          <div className="button-container">
+        ) : ( */}
+          {/* <div className="button-container">
             <Button
               text="Browse"
               width={'144px'}
               onClick={() => setShowBrowseApplication(true)}
             />
             <Button text="Upload" width={'144px'} onClick={onUploadClick} />
-          </div>
-        )}
+          </div> */}
+        {/* )} */}
       </div>
       <div className="init-section">
-        <div className="init-title">
+        {/* <div className="init-title">
           <input
             className="form-check-input"
             type="checkbox"
@@ -290,8 +291,8 @@ export default function StartContextCard({
             onChange={() => setIsArgsChecked(!isArgsChecked)}
           />
           <div className="section-title">{t.initSectionTitle}</div>
-        </div>
-        {isArgsChecked && (
+        </div> */}
+        {/* {isArgsChecked && (
           <div className="args-section">
             <div className="section-title">{t.argsTitleText}</div>
             <div className="input">
@@ -308,7 +309,25 @@ export default function StartContextCard({
               </div>
             </div>
           </div>
-        )}
+        )} */}
+        <div className="application-section">
+          <div className="appplication-title">{t.applicationLabelText}</div>
+          <select
+            className="application-input"
+            onChange={(e) => setApplicationId(e.target.value)}
+            defaultValue=""
+            required
+          >
+            <option value="" disabled>
+              Select an application
+            </option>
+            {applications.length > 0 && applications.map((app, i) => (
+              <option key={i} value={app.id}>
+                {app.id}
+              </option>
+            ))}
+          </select>
+        </div>
         <div className="protocol-section">
           <div className="protocol-title">{t.protocolLabelText}</div>
           <select

--- a/src/components/publishApplication/PublishApplicationTable.tsx
+++ b/src/components/publishApplication/PublishApplicationTable.tsx
@@ -74,7 +74,7 @@ export default function PublishApplicationTable({
           deployerAccount={deployerAccount?.accountId}
         />
 
-        {deployerAccount && (
+        {!deployerAccount && (
           <>
             <AddPackageForm
               packageInfo={packageInfo}

--- a/src/constants/en.global.json
+++ b/src/constants/en.global.json
@@ -161,6 +161,7 @@
       "releaseDetailsLabel": "Release Details",
       "installErrorTitle": "Failed to install application",
       "selectApplicationTitle": "Select app from the marketplace or publish new application",
+      "selectApplicationTitleNew": "Select application to install",
       "selectedApplicationTitle": "Selected Application",
       "installButtonText": "Install application",
       "idLabelText": "Application ID: ",
@@ -301,8 +302,10 @@
   "startContextPage": {
     "backButtonText": "back to context select",
     "selectApplicationTitle": "Select app from the marketplace or publish new application",
+    "selectApplicationTitleNew": "Select one of installed application to create context",
     "selectedApplicationTitle": "Selected Application",
     "protocolLabelText": "Protocol",
+    "applicationLabelText": "Application",
     "initSectionTitle": "Initialize application state",
     "argsTitleText": "Arguments",
     "methodLabelText": "method name",
@@ -316,7 +319,7 @@
       "noOwnedAppsText": "No owned applications installed"
     },
     "startContextSuccessTitle": "Context started",
-    "startedContextMessage": "Application context has been started successfully.",
+    "startedContextMessage": "Application context has been started successfully. Context ID: {0}, Identity Public Key: {1}",
     "startContextErrorTitle": "Failed to start context",
     "startContextErrorMessage": "Failed to start the application context.",
     "idLabelText": "Application ID: ",

--- a/src/pages/Applications.tsx
+++ b/src/pages/Applications.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import React from 'react';
 import { Navigation } from '../components/Navigation';
 import { FlexLayout } from '../components/layout/FlexLayout';
-import { useRPC } from '../hooks/useNear';
+//import { useRPC } from '../hooks/useNear';
 import { useNavigate } from 'react-router-dom';
 import apiClient from '../api/index';
 import PageContentWrapper from '../components/common/PageContentWrapper';
@@ -41,16 +41,16 @@ export interface Release {
 }
 
 const initialOptions = [
-  {
-    name: 'Available',
-    id: ApplicationOptions.AVAILABLE,
-    count: 0,
-  },
-  {
-    name: 'Owned',
-    id: ApplicationOptions.OWNED,
-    count: 0,
-  },
+  // {
+  //   name: 'Available',
+  //   id: ApplicationOptions.AVAILABLE,
+  //   count: 0,
+  // },
+  // {
+  //   name: 'Owned',
+  //   id: ApplicationOptions.OWNED,
+  //   count: 0,
+  // },
   {
     name: 'Installed',
     id: ApplicationOptions.INSTALLED,
@@ -67,10 +67,10 @@ export interface Applications {
 export default function ApplicationsPage() {
   const navigate = useNavigate();
   const { showServerDownPopup } = useServerDown();
-  const { getPackages, getLatestRelease, getPackage } = useRPC();
+  // const { getPackages, getLatestRelease, getPackage } = useRPC();
   const [errorMessage, setErrorMessage] = useState('');
   const [currentOption, setCurrentOption] = useState<string>(
-    ApplicationOptions.AVAILABLE,
+    ApplicationOptions.INSTALLED,
   );
   const [tableOptions] = useState<TableOptions[]>(initialOptions);
   const [applications, setApplications] = useState<Applications>({
@@ -87,41 +87,41 @@ export default function ApplicationsPage() {
     error: false,
   });
 
-  useEffect(() => {
-    const setApplicationsList = async () => {
-      const packages = await getPackages();
-      if (packages.length !== 0) {
-        var tempApplications: Application[] = await Promise.all(
-          packages.map(async (appPackage: Package) => {
-            const releaseData = await getLatestRelease(appPackage.id);
+  // useEffect(() => {
+  //   const setApplicationsList = async () => {
+  //     const packages = await getPackages();
+  //     if (packages.length !== 0) {
+  //       var tempApplications: Application[] = await Promise.all(
+  //         packages.map(async (appPackage: Package) => {
+  //           const releaseData = await getLatestRelease(appPackage.id);
 
-            const application: Application = {
-              id: appPackage.id,
-              name: appPackage.name,
-              description: appPackage.description,
-              repository: appPackage.repository,
-              owner: appPackage.owner,
-              version: releaseData?.version ?? '',
-              blob: '',
-              source: '',
-              contract_app_id: appPackage.id,
-            };
-            return application;
-          }),
-        );
+  //           const application: Application = {
+  //             id: appPackage.id,
+  //             name: appPackage.name,
+  //             description: appPackage.description,
+  //             repository: appPackage.repository,
+  //             owner: appPackage.owner,
+  //             version: releaseData?.version ?? '',
+  //             blob: '',
+  //             source: '',
+  //             contract_app_id: appPackage.id,
+  //           };
+  //           return application;
+  //         }),
+  //       );
 
-        //remove all apps without release
-        tempApplications = tempApplications.filter((app) => app.version !== '');
+  //       //remove all apps without release
+  //       tempApplications = tempApplications.filter((app) => app.version !== '');
 
-        setApplications((prevState: Applications) => ({
-          ...prevState,
-          available: tempApplications,
-        }));
-      }
-    };
-    setApplicationsList();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  //       setApplications((prevState: Applications) => ({
+  //         ...prevState,
+  //         available: tempApplications,
+  //       }));
+  //     }
+  //   };
+  //   setApplicationsList();
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, []);
 
   const setApps = async () => {
     setErrorMessage('');
@@ -154,27 +154,28 @@ export default function ApplicationsPage() {
                 repository: null,
                 owner: null,
               };
-            } else {
-              const [packageData, releaseData]: [
-                Package | null,
-                Release | null,
-              ] = await Promise.all([
-                getPackage(appMetadata.contractAppId),
-                getLatestRelease(appMetadata.contractAppId),
-              ]);
-
-              if (packageData) {
-                application = {
-                  ...app,
-                  contract_app_id: appMetadata.contractAppId,
-                  name: packageData?.name ?? '',
-                  description: packageData?.description,
-                  repository: packageData?.repository,
-                  owner: packageData?.owner,
-                  version: releaseData?.version ?? '',
-                };
-              }
             }
+            // } else {
+            //   const [packageData, releaseData]: [
+            //     Package | null,
+            //     Release | null,
+            //   ] = await Promise.all([
+            //     getPackage(appMetadata.contractAppId),
+            //     getLatestRelease(appMetadata.contractAppId),
+            //   ]);
+
+            //   if (packageData) {
+            //     application = {
+            //       ...app,
+            //       contract_app_id: appMetadata.contractAppId,
+            //       name: packageData?.name ?? '',
+            //       description: packageData?.description,
+            //       repository: packageData?.repository,
+            //       owner: packageData?.owner,
+            //       version: releaseData?.version ?? '',
+            //     };
+            //   }
+            // }
 
             return application;
           },

--- a/src/pages/PublishApplication.tsx
+++ b/src/pages/PublishApplication.tsx
@@ -70,6 +70,10 @@ export default function PublishApplicationPage() {
   });
 
   useEffect(() => {
+    navigate('/applications');
+  }, []);
+
+  useEffect(() => {
     (async () => {
       setPackages(await getPackages());
     })();

--- a/src/pages/StartContext.tsx
+++ b/src/pages/StartContext.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Navigation } from '../components/Navigation';
 import { FlexLayout } from '../components/layout/FlexLayout';
 import PageContentWrapper from '../components/common/PageContentWrapper';
@@ -8,6 +8,9 @@ import StartContextCard from '../components/context/startContext/StartContextCar
 import translations from '../constants/en.global.json';
 import apiClient from '../api/index';
 import { useServerDown } from '../context/ServerDownContext';
+// import { Application } from './InstallApplication';
+import { ResponseData } from '../api/response';
+import { GetInstalledApplicationsResponse, InstalledApplication } from '../api/dataSource/NodeDataSource';
 
 export interface ContextApplication {
   appId: string;
@@ -21,13 +24,7 @@ export default function StartContextPage() {
   const t = translations.startContextPage;
   const navigate = useNavigate();
   const { showServerDownPopup } = useServerDown();
-  const [application, setApplication] = useState<ContextApplication>({
-    appId: '',
-    name: '',
-    version: '',
-    path: '',
-    hash: '',
-  });
+  const [applicationId, setApplicationId] = useState('');
   const [isArgsChecked, setIsArgsChecked] = useState(false);
   const [argumentsJson, setArgumentsJson] = useState('');
   const [showBrowseApplication, setShowBrowseApplication] = useState(false);
@@ -39,18 +36,19 @@ export default function StartContextPage() {
     message: '',
     error: false,
   });
+  const [applications, setApplications] = useState<InstalledApplication[]>([]);
 
   const startContext = async () => {
     setIsLoading(true);
-    const appId: string | null = await installApplicationHandler();
-    if (!appId) {
-      setIsLoading(false);
-      setShowStatusModal(true);
-      return;
-    }
+    // const appId: string | null = await installApplicationHandler();
+    // if (!appId) {
+    //   setIsLoading(false);
+    //   setShowStatusModal(true);
+    //   return;
+    // }
     const startContextResponse = await apiClient(showServerDownPopup)
       .node()
-      .createContexts(appId, argumentsJson, protocol);
+      .createContexts(applicationId, argumentsJson, protocol);
     if (startContextResponse.error) {
       setStartContextStatus({
         title: t.startContextErrorTitle,
@@ -58,9 +56,11 @@ export default function StartContextPage() {
         error: true,
       });
     } else {
+      const newConextId = startContextResponse.data?.contextId;
+      const identityPublicKey = startContextResponse.data?.memberPublicKey;
       setStartContextStatus({
         title: t.startContextSuccessTitle,
-        message: t.startedContextMessage,
+        message: t.startedContextMessage.replace('{0}', newConextId).replace('{1}', identityPublicKey),
         error: false,
       });
     }
@@ -68,35 +68,35 @@ export default function StartContextPage() {
     setShowStatusModal(true);
   };
 
-  const installApplicationHandler = async (): Promise<string | null> => {
-    if (!application.appId || !application.version) {
-      return null;
-    }
+  // const installApplicationHandler = async (): Promise<string | null> => {
+  //   if (!applicationId) {
+  //     return null;
+  //   }
 
-    const response = await apiClient(showServerDownPopup)
-      .node()
-      .installApplication(
-        application.appId,
-        application.version,
-        application.path,
-        application.hash,
-      );
-    if (response.error) {
-      setStartContextStatus({
-        title: t.failInstallTitle,
-        message: response.error.message,
-        error: true,
-      });
-      return null;
-    } else {
-      setStartContextStatus({
-        title: t.successInstallTitle,
-        message: `Installed application ${application.name}, version ${application.version}.`,
-        error: false,
-      });
-      return response.data.applicationId;
-    }
-  };
+  //   const response = await apiClient(showServerDownPopup)
+  //     .node()
+  //     .installApplication(
+  //       application.appId,
+  //       application.version,
+  //       application.path,
+  //       application.hash,
+  //     );
+  //   if (response.error) {
+  //     setStartContextStatus({
+  //       title: t.failInstallTitle,
+  //       message: response.error.message,
+  //       error: true,
+  //     });
+  //     return null;
+  //   } else {
+  //     setStartContextStatus({
+  //       title: t.successInstallTitle,
+  //       message: `Installed application ${applicationId}`,
+  //       error: false,
+  //     });
+  //     return response.data.applicationId;
+  //   }
+  // };
 
   const closeModal = () => {
     setShowStatusModal(false);
@@ -111,6 +111,15 @@ export default function StartContextPage() {
     navigate('/contexts');
   };
 
+  useEffect(() => {
+    const fetchApplication = async () => {
+      const fetchApplicationResponse: ResponseData<GetInstalledApplicationsResponse> =
+        await apiClient(showServerDownPopup).node().getInstalledApplications();
+      setApplications(fetchApplicationResponse.data?.apps ?? []);
+    };
+    fetchApplication();
+  }, []);
+
   return (
     <FlexLayout>
       <Navigation />
@@ -120,8 +129,8 @@ export default function StartContextPage() {
           headerOnBackClick={() => navigate('/contexts')}
         >
           <StartContextCard
-            application={application}
-            setApplication={setApplication}
+            applicationId={applicationId}
+            setApplicationId={setApplicationId}
             isArgsChecked={isArgsChecked}
             setIsArgsChecked={setIsArgsChecked}
             argumentsJson={argumentsJson}
@@ -135,6 +144,7 @@ export default function StartContextPage() {
             showStatusModal={showStatusModal}
             closeModal={closeModal}
             startContextStatus={startContextStatus}
+            applications={applications}
           />
         </ContentCard>
       </PageContentWrapper>


### PR DESCRIPTION
# feat: replace NEAR apps registry

## Description
NEAR registry along with blobby service is used to:
1. Upload wasm files to IPFS
2. Save blobby url to files with all application metadata to smart contract on NEAR (apps registry)

With this PR few FE parts are changed to be simplified - e.g. context creation

Application install is still up for discussion as there are multiple ways to handle replacement of blobby + NEAR.

![Screenshot 2025-06-05 at 12 30 28](https://github.com/user-attachments/assets/75a2a25a-f080-459c-81f5-3607ed8edd98)
![Screenshot 2025-06-05 at 12 37 58](https://github.com/user-attachments/assets/287db652-d8d7-49e0-9b91-f3d8eba8f75e)
