### PR TITLE
feat: add reviewer ci

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -1,0 +1,66 @@
+name: AI Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: number
+      agents:
+        description: "Number of agents (1-5)"
+        required: false
+        default: "3"
+        type: choice
+        options: ["1", "2", "3", "4", "5"]
+
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install ai-code-reviewer
+        run: pip install ai-code-reviewer
+
+      - name: Determine PR number and agent count
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "agents=${{ github.event.inputs.agents }}"    >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "agents=3"                                        >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run AI Code Review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          ai-reviewer review-pr \
+            ${{ github.repository }} \
+            ${{ steps.pr.outputs.number }} \
+            --agents ${{ steps.pr.outputs.agents }} \
+            --reviewer-name "MeroReviewer" \
+            --output github

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to review"
+        description: 'PR number to review'
         required: true
         type: number
       agents:
-        description: "Number of agents (1-5)"
+        description: 'Number of agents (1-5)'
         required: false
-        default: "3"
+        default: '3'
         type: choice
-        options: ["1", "2", "3", "4", "5"]
+        options: ['1', '2', '3', '4', '5']
 
 concurrency:
   group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: '3.11'
           cache: pip
 
       - name: Install ai-code-reviewer

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to review"
+        description: 'PR number to review'
         required: true
         type: number
       agents:
-        description: "Number of agents (1-5)"
+        description: 'Number of agents (1-5)'
         required: false
-        default: "3"
+        default: '3'
         type: choice
-        options: ["1", "2", "3", "4", "5"]
+        options: ['1', '2', '3', '4', '5']
 
 concurrency:
   group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
       - name: Install ai-code-reviewer
         run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to review'
+        description: "PR number to review"
         required: true
         type: number
       agents:
-        description: 'Number of agents (1-5)'
+        description: "Number of agents (1-5)"
         required: false
-        default: '3'
+        default: "3"
         type: choice
-        options: ['1', '2', '3', '4', '5']
+        options: ["1", "2", "3", "4", "5"]
 
 concurrency:
   group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
@@ -36,8 +36,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-          cache: pip
+          python-version: "3.11"
 
       - name: Install ai-code-reviewer
         run: pip install ai-code-reviewer

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -39,7 +39,9 @@ jobs:
           python-version: "3.11"
 
       - name: Install ai-code-reviewer
-        run: pip install ai-code-reviewer
+        run: |
+          pip install ai-code-reviewer
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Determine PR number and agent count
         id: pr

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -2,19 +2,19 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to review'
+        description: "PR number to review"
         required: true
         type: number
       agents:
-        description: 'Number of agents (1-5)'
+        description: "Number of agents (1-5)"
         required: false
-        default: '3'
+        default: "3"
         type: choice
-        options: ['1', '2', '3', '4', '5']
+        options: ["1", "2", "3", "4", "5"]
 
 concurrency:
   group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
@@ -36,12 +36,10 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install ai-code-reviewer
-        run: |
-          pip install ai-code-reviewer
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git
 
       - name: Determine PR number and agent count
         id: pr

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to review"
+        description: 'PR number to review'
         required: true
         type: number
       agents:
-        description: "Number of agents (1-5)"
+        description: 'Number of agents (1-5)'
         required: false
-        default: "3"
+        default: '3'
         type: choice
-        options: ["1", "2", "3", "4", "5"]
+        options: ['1', '2', '3', '4', '5']
 
 concurrency:
   group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
       - name: Install ai-code-reviewer
         run: |

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to generate docs for (leave blank to auto-detect)"
+        description: 'PR number to generate docs for (leave blank to auto-detect)'
         type: string
         required: false
       dry_run:
-        description: "Dry run: print changes without opening a PR"
+        description: 'Dry run: print changes without opening a PR'
         type: boolean
         default: false
 

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -1,0 +1,24 @@
+name: Doc Auto-Update
+
+on:
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to generate docs for (leave blank to auto-detect)"
+        type: string
+        required: false
+      dry_run:
+        description: "Dry run: print changes without opening a PR"
+        type: boolean
+        default: false
+
+jobs:
+  doc-update:
+    uses: calimero-network/ai-code-reviewer/.github/workflows/doc-update.yaml@main
+    with:
+      dry_run: ${{ github.event.inputs.dry_run == 'true' }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to generate docs for (leave blank to auto-detect)'
+        description: "PR number to generate docs for (leave blank to auto-detect)"
         type: string
         required: false
       dry_run:
-        description: 'Dry run: print changes without opening a PR'
+        description: "Dry run: print changes without opening a PR"
         type: boolean
         default: false
 
@@ -19,6 +19,7 @@ jobs:
     uses: calimero-network/ai-code-reviewer/.github/workflows/doc-update.yaml@main
     with:
       dry_run: ${{ github.event.inputs.dry_run == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new CI automation with elevated `pull-requests: write` permissions and uses repository secrets to call external tooling, so misconfiguration could spam PRs or leak/overuse credentials.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/ai-review.yaml`) that runs an automated AI review on PR events (and manually via `workflow_dispatch`), including concurrency control, configurable agent count, and PR write permissions to post results.
> 
> Adds a second workflow (`.github/workflows/doc-update.yaml`) that triggers on pushes to `main/master` (or manually) and delegates doc generation/updates to the shared `calimero-network/ai-code-reviewer` reusable workflow, passing through `ANTHROPIC_API_KEY`/`GH_PAT` secrets and an optional dry-run mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c668f8c2d2ffeb2d66a3b36c0d1698f245c43126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->