### PR TITLE
fix: follow core rc.23, which deleted the two identity APIs 1.13.0 uses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .merod
-          key: merod-${{ runner.os }}-${{ runner.arch }}-0.11.0-rc.20
+          key: merod-${{ runner.os }}-${{ runner.arch }}-0.11.0-rc.23
 
       - name: Download merod
         if: steps.merod-cache.outputs.cache-hit != 'true'

--- a/e2e-live/namespaces.live.spec.ts
+++ b/e2e-live/namespaces.live.spec.ts
@@ -19,9 +19,16 @@ import {
  *   • display names are `name` on the wire, not `alias`;
  *   • the subgroup-creation endpoint reads `groupName`, so a request carrying
  *     only `name` is accepted and the name is dropped;
- *   • `GET /groups/:id/members` answers `{ members, selfIdentity }` and
+ *   • `GET /groups/:id/members` answers `{ members }` and
  *     `GET /groups/:id/subgroups` answers `{ subgroups }` — neither is the
  *     `{ data }` envelope the rest of the API uses.
+ *
+ * And one that failed LOUDLY, in released code: core 0.11.0-rc.23 deleted
+ * `GET /namespaces/:id/identity` (#3522) and dropped `selfIdentity` from the
+ * member list. 1.13.0 of this dashboard used both. Against a real rc.23 node
+ * the "you" badge and the Delete-vs-Leave choice come from
+ * `GET /admin-api/identity` — an account, 64 hex characters, matched against a
+ * member row's `identity`.
  *
  * So these tests assert on names, not just ids: a name that survives the round
  * trip is the proof.
@@ -136,10 +143,38 @@ test.describe.serial('Live: namespaces', () => {
     ).toBeVisible();
 
     // The creator is a member of their own namespace, so an empty list here
-    // means the `{ members, selfIdentity }` envelope was misread.
+    // means the `{ members }` envelope was misread.
     const members = page.getByTestId('ns-members-section');
     await expect(members).not.toContainText('Members (0)');
+    // And "you" proves the node-level identity call lines up with the member
+    // rows — the account this node writes as is a row in its own namespace.
     await expect(members.getByText('you')).toBeVisible();
+
+    // The identity panel is node-level now. There is no per-namespace answer to
+    // show, and the route that pretended there was is gone.
+    const identity = page.getByTestId('ns-identity-section');
+    await expect(identity).toContainText('Your account');
+    await expect(identity).toContainText('Signing key');
+  });
+
+  test('the per-namespace identity route is gone, and the node-level one answers', async () => {
+    // Pin the break directly against the node, not just through the UI: if a
+    // future node revives the namespaced route, this fails and we learn about
+    // it rather than silently drifting back onto it.
+    const { status } = await adminApi(
+      'GET',
+      `/namespaces/${createdNamespaceId}/identity`,
+    );
+    expect(status).toBe(404);
+
+    const { status: nodeStatus, body } = await adminApi<{
+      data?: { accountId?: string; publicKey?: string };
+    }>('GET', '/identity');
+    expect(nodeStatus).toBe(200);
+    // An ACCOUNT renders as 64 hex characters; the signing key is base58 and is
+    // deliberately a different alphabet so a mix-up cannot resolve silently.
+    expect(body.data?.accountId).toMatch(/^[0-9a-f]{64}$/);
+    expect(body.data?.publicKey).not.toMatch(/^[0-9a-f]{64}$/);
   });
 
   test('creates a named subgroup, and the name persists', async ({ page }) => {

--- a/e2e-merobox/membership.merobox.spec.ts
+++ b/e2e-merobox/membership.merobox.spec.ts
@@ -179,18 +179,27 @@ test.describe.serial('Merobox: membership between two nodes', () => {
 
     const members = page.getByTestId('ns-members-section');
     await expect(members).toContainText('Members (2)');
-    // Exactly one row is the local node — `selfIdentity` off the member-list
-    // response, not a guess from the JWT.
+    // Exactly one row is the local node — its ACCOUNT, read from
+    // `GET /admin-api/identity`, not a guess from the JWT. rc.23 removed
+    // `selfIdentity` from the member-list response.
     await expect(members.getByText('you')).toHaveCount(1);
   });
 
   test('promoting bob reaches bob', async ({ page }) => {
+    // Tell the two rows apart by asking alice's node who IT is: the member
+    // list carries `members` and nothing else since rc.23, so the one row that
+    // is not alice's own account is bob's.
+    const { body: aliceIdentity } = await aliceApi.get<{
+      data?: { accountId?: string };
+    }>('/identity');
+    const aliceAccount = aliceIdentity.data?.accountId;
+    expect(aliceAccount, 'alice has no account id').toBeTruthy();
+
     const { body: before } = await aliceApi.get<{
       members?: { identity: string; role: string }[];
-      selfIdentity?: string;
     }>(`/groups/${namespaceId}/members`);
     const bobIdentity = (before.members ?? []).find(
-      (m) => m.identity !== before.selfIdentity,
+      (m) => m.identity !== aliceAccount,
     )?.identity;
     expect(bobIdentity, 'could not tell the two members apart').toBeTruthy();
 

--- a/e2e/fixtures/node.ts
+++ b/e2e/fixtures/node.ts
@@ -96,6 +96,16 @@ export interface MockNodeOptions {
   /** `GET /admin-api/namespaces`. */
   namespaces?: MockNamespace[];
   /**
+   * `GET /admin-api/identity` — who this node is.
+   *
+   * Node-level, taking no namespace: core 0.11.0-rc.23 deleted
+   * `GET /namespaces/:id/identity` (#3522) because it answered with the node's
+   * account whichever namespace you passed. Set to `null` to serve the 404 a
+   * node that has joined nothing answers with, which is a normal state and must
+   * not break the page.
+   */
+  nodeIdentity?: MockNodeIdentity | null;
+  /**
    * Per-group state, keyed by group id. A namespace IS a group, so its own
    * root entry is keyed by the namespace id.
    */
@@ -119,16 +129,36 @@ export interface MockNamespace {
   subgroupCount?: number;
 }
 
+export interface MockNodeIdentity {
+  /** 64 HEX characters. This is what a member row's `identity` holds. */
+  accountId: string;
+  /** Hex `DeviceId`. Absent on a node that has not enrolled yet. */
+  deviceId?: string;
+  /** base58 — the device's SIGNING key, which never appears in a member list. */
+  publicKey: string;
+  accountRootPublicKey?: string;
+}
+
 export interface MockGroup {
   /** Display name — lives in group metadata on the wire, not at the top level. */
   name?: string;
   subgroupVisibility?: string;
+  /**
+   * `identity` is an ACCOUNT (64 hex), not a key. rc.23 keys membership rows by
+   * the person rather than by one of their device keys.
+   */
   members?: { identity: string; role: string; name?: string }[];
-  /** The node reports the caller's own identity alongside the member list. */
-  selfIdentity?: string;
   contexts?: { contextId: string; name?: string }[];
   subgroups?: { groupId: string; name?: string }[];
 }
+
+/** A node identity whose ids are shaped the way the real ones are. */
+export const NODE_IDENTITY: MockNodeIdentity = {
+  accountId: 'ac'.repeat(32),
+  deviceId: 'de'.repeat(32),
+  publicKey: '2Fb1JXPZQZmGRoLPS9F6JsPRRTL1cKnQfCzYAeZLmDaG',
+  accountRootPublicKey: 'r0'.repeat(32),
+};
 
 const json = (route: Route, body: unknown, status = 200) =>
   route.fulfill({
@@ -229,13 +259,27 @@ export async function mockNode(page: Page, opts: MockNodeOptions = {}) {
     json(route, { data: { namespaces: [] } }),
   );
 
+  // `GET /admin-api/identity`. `nodeIdentity: null` opts into the 404 a node
+  // that holds neither a device nor an account root answers — the page must
+  // still render, just without marking anyone "you".
+  const nodeIdentity =
+    opts.nodeIdentity === undefined ? NODE_IDENTITY : opts.nodeIdentity;
+  await page.route('**/admin-api/identity', (route) =>
+    nodeIdentity
+      ? json(route, { data: nodeIdentity })
+      : json(
+          route,
+          { error: 'this node holds neither a device nor a root' },
+          404,
+        ),
+  );
+
   // Namespaces + groups (raw fetches in src/api/namespaceApi.ts).
   //
   // One dispatcher per prefix rather than a glob per endpoint: the response
-  // ENVELOPES differ between these routes (`{ data }` vs `{ members,
-  // selfIdentity }` vs `{ subgroups }`), and matching on the parsed path makes
-  // that explicit instead of depending on Playwright's reverse-order glob
-  // resolution.
+  // ENVELOPES differ between these routes (`{ data }` vs `{ members }` vs
+  // `{ subgroups }`), and matching on the parsed path makes that explicit
+  // instead of depending on Playwright's reverse-order glob resolution.
   const namespaces = opts.namespaces ?? [];
   const groups = opts.groups ?? {};
   const groupOf = (id: string): MockGroup => groups[id] ?? {};
@@ -258,9 +302,10 @@ export async function mockNode(page: Page, opts: MockNodeOptions = {}) {
         })),
       });
     }
-    if (sub === 'identity') {
-      return json(route, { namespaceId: id, publicKey: `pk-${id}` });
-    }
+    // No `identity` branch on purpose. rc.23 deleted
+    // `GET /namespaces/:id/identity`, so it falls through to the catch-all
+    // below — anything that starts calling it again reads `{}` and fails
+    // visibly rather than being quietly served a shape the node no longer has.
     if (sub === 'groups') {
       return json(route, { data: groupOf(id).subgroups ?? [] });
     }
@@ -273,11 +318,11 @@ export async function mockNode(page: Page, opts: MockNodeOptions = {}) {
       /\/admin-api\/groups(?:\/([^/]+))?(?:\/([^/]+))?/.exec(path) ?? [];
     const group = id ? groupOf(id) : {};
 
+    // `{ members }` and nothing else. rc.23 removed `selfIdentity` from this
+    // response; serving it anyway would keep the suite green against a shape
+    // the node no longer sends, which is the whole point of pinning it here.
     if (sub === 'members') {
-      return json(route, {
-        members: group.members ?? [],
-        ...(group.selfIdentity ? { selfIdentity: group.selfIdentity } : {}),
-      });
+      return json(route, { members: group.members ?? [] });
     }
     if (sub === 'contexts') {
       return json(route, { data: group.contexts ?? [] });

--- a/e2e/namespaces.spec.ts
+++ b/e2e/namespaces.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
-import { ABI_WITH_INIT, APP_WITH_FRONTEND, mockNode } from './fixtures/node';
+import {
+  ABI_WITH_INIT,
+  APP_WITH_FRONTEND,
+  NODE_IDENTITY,
+  mockNode,
+} from './fixtures/node';
 
 /**
  * Namespaces is now the only place the group hierarchy is managed — the
@@ -7,15 +12,25 @@ import { ABI_WITH_INIT, APP_WITH_FRONTEND, mockNode } from './fixtures/node';
  * group and a node-global list of them mapped onto nothing.
  *
  * These run against the mocked node, so they also pin the WIRE SHAPES the page
- * depends on: `name` (not `alias`) for every display name, `{ members,
- * selfIdentity }` for the member list and `{ subgroups }` for subgroups — all
- * three of which were being unwrapped wrongly and silently rendered as empty.
+ * depends on: `name` (not `alias`) for every display name, `{ members }` for the
+ * member list and `{ subgroups }` for subgroups — all three of which were being
+ * unwrapped wrongly and silently rendered as empty.
+ *
+ * The member list is `{ members }` and nothing else as of core 0.11.0-rc.23:
+ * `selfIdentity` was removed, and "you" is now decided by comparing each row's
+ * ACCOUNT against `GET /admin-api/identity`. The fixture must not keep serving
+ * the old field, or the suite stays green against a shape the node no longer
+ * sends — which is exactly how 1.13.0 shipped broken.
  */
 
 const NS_ID = 'ns1111111111111111111111111111111111111111111111';
 const SUB_ID = 'sub22222222222222222222222222222222222222222222';
 const CTX_ID = 'ctx33333333333333333333333333333333333333333333';
-const ME = 'meidentity4444444444444444444444444444444444444';
+// A member id is an ACCOUNT now — 64 hex characters, not the base58 a key
+// renders as — and ours has to equal what `/admin-api/identity` reports or no
+// row is "you".
+const ME = NODE_IDENTITY.accountId;
+const OTHER = 'ff'.repeat(32);
 
 const FIXTURE = {
   namespaces: [
@@ -33,9 +48,8 @@ const FIXTURE = {
     [NS_ID]: {
       members: [
         { identity: ME, role: 'Admin', name: 'Fran' },
-        { identity: 'other5555555555555555555555555555555', role: 'Member' },
+        { identity: OTHER, role: 'Member', name: 'other' },
       ],
-      selfIdentity: ME,
       contexts: [{ contextId: CTX_ID, name: 'general' }],
       subgroups: [{ groupId: SUB_ID, name: 'engineering' }],
     },
@@ -43,7 +57,6 @@ const FIXTURE = {
       name: 'engineering',
       subgroupVisibility: 'restricted',
       members: [{ identity: ME, role: 'Member' }],
-      selfIdentity: ME,
       contexts: [],
       subgroups: [],
     },
@@ -108,8 +121,50 @@ test.describe('Namespaces', () => {
     const members = page.getByTestId('ns-members-section');
     await expect(members).toContainText('Members (2)');
     await expect(members).toContainText('Fran');
-    // `selfIdentity` from the member-list response identifies the caller.
+    // "you" is the row whose ACCOUNT matches `GET /admin-api/identity`. The
+    // member list no longer says which one that is.
     await expect(members.getByText('you')).toBeVisible();
+  });
+
+  test('a node with no identity yet still renders the members table', async ({
+    page,
+  }) => {
+    // `/admin-api/identity` 404s on a node that holds neither a device nor an
+    // account root — it has taken part in nothing. That is a normal state, so
+    // the page must render, just with nobody marked "you" and no error.
+    await mockNode(page, { ...FIXTURE, nodeIdentity: null });
+    await page.goto('/admin-dashboard/namespaces');
+    await page.getByTestId('ns-card').click();
+
+    const members = page.getByTestId('ns-members-section');
+    await expect(members).toContainText('Members (2)');
+    await expect(members.getByText('you')).toHaveCount(0);
+    await expect(page.getByTestId('ns-identity-section')).toHaveCount(0);
+  });
+
+  test('the identity panel names the node, not the namespace', async ({
+    page,
+  }) => {
+    // rc.23 deleted `GET /namespaces/:id/identity` (#3522), so there is no
+    // "your namespace identity" left to show. Asking a namespace who you are
+    // always answered with the node's account.
+    await mockNode(page, FIXTURE);
+    let namespacedIdentityCalls = 0;
+    await page.route('**/admin-api/namespaces/*/identity', (route) => {
+      namespacedIdentityCalls += 1;
+      return route.fulfill({ status: 404, body: '{}' });
+    });
+
+    await page.goto('/admin-dashboard/namespaces');
+    await page.getByTestId('ns-card').click();
+
+    const panel = page.getByTestId('ns-identity-section');
+    await expect(panel).toContainText('Your account');
+    // Both encodings on screen, each labelled: the account is what the members
+    // table is keyed by, the signing key is what an add-member call takes.
+    await expect(panel).toContainText(NODE_IDENTITY.accountId.slice(0, 10));
+    await expect(panel).toContainText(NODE_IDENTITY.publicKey.slice(0, 10));
+    expect(namespacedIdentityCalls).toBe(0);
   });
 
   test('members can be promoted and demoted', async ({ page }) => {
@@ -129,15 +184,49 @@ test.describe('Namespaces', () => {
       memberRow.getByRole('button', { name: 'Demote' }),
     ).toBeVisible();
 
-    const putRoles: string[] = [];
+    const putPaths: string[] = [];
     await page.route('**/admin-api/groups/*/members/*/role', async (route) => {
-      putRoles.push(route.request().method());
+      putPaths.push(new URL(route.request().url()).pathname);
+      expect(route.request().method()).toBe('PUT');
+      // `requester` was dropped from every admin request body in rc.23
+      // (core #3492), so the body carries the role and nothing else.
+      expect(route.request().postDataJSON()).toEqual({ role: 'Admin' });
       await route.fulfill({ status: 200, body: '{}' });
     });
     await memberRow.getByRole('button', { name: 'Promote' }).click();
     // The toast is page-level, not inside the section.
     await expect(page.getByText('Role set to Admin')).toBeVisible();
-    expect(putRoles).toEqual(['PUT']);
+    // core's path segment is `:account`, so the member is addressed by the
+    // 64-hex account the listing returned — not by any key.
+    expect(putPaths).toEqual([
+      `/admin-api/groups/${NS_ID}/members/${OTHER}/role`,
+    ]);
+  });
+
+  test('add-member refuses an account, because that endpoint takes a key', async ({
+    page,
+  }) => {
+    // The one asymmetry left on this resource: add names a base58 PublicKey,
+    // every other verb names a 64-hex AccountId. Copying an id out of the table
+    // into this box addresses nobody, so say so instead of letting the node
+    // answer with a bare error.
+    await mockNode(page, FIXTURE);
+    await page.goto('/admin-dashboard/namespaces');
+    await page.getByTestId('ns-card').click();
+
+    const members = page.getByTestId('ns-members-section');
+    await members.getByRole('button', { name: 'Add Member' }).click();
+    const field = members.getByPlaceholder('Public key (base58)');
+
+    await field.fill(OTHER);
+    await expect(page.getByTestId('ns-add-member-hint')).toBeVisible();
+    // `exact` matters: "Add Member" also matches a loose name.
+    const submit = members.getByRole('button', { name: 'Add', exact: true });
+    await expect(submit).toBeDisabled();
+
+    await field.fill(NODE_IDENTITY.publicKey);
+    await expect(page.getByTestId('ns-add-member-hint')).toHaveCount(0);
+    await expect(submit).toBeEnabled();
   });
 
   test('opening a subgroup shows its own members and visibility', async ({

--- a/scripts/prepare-merod.mjs
+++ b/scripts/prepare-merod.mjs
@@ -12,7 +12,12 @@ import { existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 
 const CORE_REPO = 'calimero-network/core';
-const MEROD_VERSION = process.env['MEROD_VERSION'] ?? '0.11.0-rc.20';
+// Keep this in step with the API surface the dashboard targets. rc.23 deleted
+// `GET /namespaces/:id/identity` and dropped `selfIdentity` from the member
+// list, so a suite still pinned to rc.20 would keep passing against shapes the
+// node no longer sends — which is precisely how 1.13.0 shipped broken.
+// The cache key in .github/workflows/ci.yml names this version too.
+const MEROD_VERSION = process.env['MEROD_VERSION'] ?? '0.11.0-rc.23';
 
 const rootDir = path.resolve(import.meta.dirname, '..');
 const binDir = path.join(rootDir, '.merod');

--- a/src/api/namespaceApi.ts
+++ b/src/api/namespaceApi.ts
@@ -16,10 +16,16 @@ import {
  *    the API and nowhere else since — reading `alias` yields `undefined`,
  *    which is why names silently never rendered.
  *  • Response envelopes are NOT uniform. Most endpoints answer `{ data: T }`,
- *    but `listGroupMembers` answers `{ members, selfIdentity }` and
- *    `listSubgroups` answers `{ subgroups }` — unwrapping `.data` on those
- *    gives `undefined`, and a naive `Array.isArray` guard then renders an
- *    empty list instead of failing loudly.
+ *    but `listGroupMembers` answers `{ members }` and `listSubgroups` answers
+ *    `{ subgroups }` — unwrapping `.data` on those gives `undefined`, and a
+ *    naive `Array.isArray` guard then renders an empty list instead of failing
+ *    loudly.
+ *  • A member is named by TWO different ids depending on the verb, and they
+ *    are deliberately rendered in different alphabets so a mix-up fails loudly
+ *    instead of resolving to the wrong principal. Since core 0.11.0-rc.23 the
+ *    listing, remove, role, capabilities and metadata calls all name a member
+ *    by ACCOUNT (`AccountId`, 64 hex characters); only add-member still names
+ *    a KEY (`PublicKey`, base58). Each affected function says which it wants.
  */
 
 // ---- Types ----
@@ -48,9 +54,28 @@ export interface Namespace {
   appVersion?: string;
 }
 
-export interface NamespaceIdentity {
-  namespaceId: string;
+/**
+ * Who this NODE is — `GET /admin-api/identity`, no namespace involved.
+ *
+ * There used to be a `GET /admin-api/namespaces/:id/identity`, and 1.13.0 of
+ * this dashboard called it. core 0.11.0-rc.23 deleted it (#3522) because it was
+ * a lie with an extra path segment: it took a namespace and answered with the
+ * node's account regardless of which one you passed. Every namespace on a node
+ * resolves to the same account, so there was never a per-namespace identity to
+ * report — asking a namespace who you are only ever made the answer look like
+ * it varied by scope.
+ */
+export interface NodeIdentity {
+  /** The account this node writes as. 64 HEX characters — this is the id the
+   *  member listing returns and every member-addressing endpoint expects. */
+  accountId: string;
+  /** Hex `DeviceId`, absent on a node that has not enrolled into an account. */
+  deviceId?: string;
+  /** The key this node signs ops with, base58 — the DEVICE key, not the
+   *  account root. Never appears in a member listing. */
   publicKey: string;
+  /** Hex epoch-0 root public key; what a second device pairs against. */
+  accountRootPublicKey?: string;
 }
 
 export interface SubgroupEntry {
@@ -82,15 +107,26 @@ export type UpgradePolicy = 'Automatic' | 'LazyOnAccess';
 export type GroupRole = 'Admin' | 'Member' | 'ReadOnly';
 
 export interface GroupMember {
+  /**
+   * The member's ACCOUNT — 64 hex characters, not the base58 a key renders as.
+   * A member is a person here, and a person may hold several keys, so the
+   * membership row is keyed by the account rather than by any one device key.
+   */
   identity: string;
   role: GroupRole | string;
   name?: string;
 }
 
+/**
+ * `{ members }` and nothing else.
+ *
+ * rc.23 removed `selfIdentity` from this response. It never belonged: it
+ * answered "who am I", which is a node-level question the member list of one
+ * group is a strange place to ask. Callers that need it read
+ * {@link getNodeIdentity} and compare `accountId` against `member.identity`.
+ */
 export interface GroupMembersResult {
   members: GroupMember[];
-  /** This node's own identity in the group, so the UI can mark "you". */
-  selfIdentity?: string | undefined;
 }
 
 export interface GroupContextEntry {
@@ -122,18 +158,61 @@ export interface CreateContextResponseData {
   groupCreated?: boolean;
 }
 
+/**
+ * The one member-addressing call that still takes a KEY.
+ *
+ * `identity` here is a base58 `PublicKey`, not the 64-hex account the listing
+ * hands back. That asymmetry is deliberate on core's side: an add is the only
+ * call whose subject may have no account on this node yet — the account is a
+ * hash of a genesis the node learns only once the person has joined — so an
+ * operator can only name them by the key they sign with. The apply resolves
+ * that key to the account the row is keyed by, and the listing is where the
+ * caller reads the account back.
+ *
+ * Pasting an id copied out of the members table here therefore addresses
+ * nobody. {@link looksLikeAccountId} exists so the UI can say so.
+ */
 export interface AddMembersRequest {
   members: Array<{ identity: string; role: GroupRole }>;
 }
 
+/** Members named by ACCOUNT (64 hex) — the principal the rows are keyed by. */
 export interface RemoveMembersRequest {
   members: string[];
+}
+
+/**
+ * True for a 64-hex `AccountId`, false for the base58 a `PublicKey` renders as.
+ *
+ * Base58 has no `0`, so a 64-character all-hex string is an account with
+ * near-certainty; this is a UI hint, not validation — the node is the authority
+ * and rejects a mismatch itself.
+ */
+export function looksLikeAccountId(value: string): boolean {
+  return /^[0-9a-f]{64}$/i.test(value.trim());
 }
 
 /** `{ invitation, groupName? }` — the unwrapped body of an invite response. */
 export interface InvitationPayload {
   invitation: Record<string, unknown>;
   groupName?: string;
+}
+
+/**
+ * What a join answers. Note the TWO ids, and which one is useful afterwards.
+ *
+ * `memberIdentity` is the base58 key the joiner signs with; `memberAccount`
+ * (added in rc.23) is the 64-hex account that key joined as, and it is the id
+ * every member-addressing endpoint expects. Anything that wants to look the new
+ * member up, change their role or remove them must use `memberAccount` —
+ * `memberIdentity` matches no row in the listing.
+ */
+export interface JoinResult {
+  groupId: string;
+  memberIdentity: string;
+  memberAccount: string;
+  /** Still present at rc.23; core#3528 to drop it is a draft. */
+  governanceOp?: string;
 }
 
 // ---- HTTP helpers ----
@@ -235,13 +314,15 @@ export async function getNamespace(namespaceId: string): Promise<Namespace> {
   return apiGet<Namespace>(`/admin-api/namespaces/${namespaceId}`);
 }
 
-export async function getNamespaceIdentity(
-  namespaceId: string,
-): Promise<NamespaceIdentity> {
-  return apiGet<NamespaceIdentity>(
-    `/admin-api/namespaces/${namespaceId}/identity`,
-    true,
-  );
+/**
+ * Who this node is. Takes no namespace, and that is the whole point of it.
+ *
+ * Rejects with 404 on a node that has taken part in nothing yet — it holds
+ * neither a device nor an account root, so there is no account to report rather
+ * than an empty one. Callers treat that as "unknown", not as an error.
+ */
+export async function getNodeIdentity(): Promise<NodeIdentity> {
+  return apiGet<NodeIdentity>('/admin-api/identity');
 }
 
 export async function createNamespace(
@@ -270,11 +351,8 @@ export async function createNamespaceInvitation(
 export async function joinNamespace(
   namespaceId: string,
   req: InvitationPayload,
-): Promise<{ groupId: string; memberIdentity: string }> {
-  return apiPost<{ groupId: string; memberIdentity: string }>(
-    `/admin-api/namespaces/${namespaceId}/join`,
-    req,
-  );
+): Promise<JoinResult> {
+  return apiPost<JoinResult>(`/admin-api/namespaces/${namespaceId}/join`, req);
 }
 
 /** Remove your own identity from the namespace (cascades to its subgroups). */
@@ -355,7 +433,10 @@ export async function createSubgroup(req: {
   });
 }
 
-/** `{ members, selfIdentity }` — NOT `{ data: [...] }`. */
+/**
+ * `{ members }` — NOT `{ data: [...] }`, and no longer `{ members,
+ * selfIdentity }`: rc.23 dropped the self field. Each `identity` is an ACCOUNT.
+ */
 export async function listGroupMembers(
   groupId: string,
 ): Promise<GroupMembersResult> {
@@ -363,10 +444,7 @@ export async function listGroupMembers(
     `/admin-api/groups/${groupId}/members`,
     true,
   );
-  return {
-    members: Array.isArray(result?.members) ? result.members : [],
-    selfIdentity: result?.selfIdentity,
-  };
+  return { members: Array.isArray(result?.members) ? result.members : [] };
 }
 
 export async function listGroupContexts(
@@ -387,6 +465,7 @@ export async function listSubgroups(groupId: string): Promise<SubgroupEntry[]> {
   return Array.isArray(result?.subgroups) ? result.subgroups : [];
 }
 
+/** Members named by KEY (base58) — the only such call. See {@link AddMembersRequest}. */
 export async function addGroupMembers(
   groupId: string,
   req: AddMembersRequest,
@@ -394,6 +473,7 @@ export async function addGroupMembers(
   await apiPost<void>(`/admin-api/groups/${groupId}/members`, req);
 }
 
+/** Members named by ACCOUNT (64 hex), exactly as `listGroupMembers` returns them. */
 export async function removeGroupMembers(
   groupId: string,
   req: RemoveMembersRequest,
@@ -401,12 +481,13 @@ export async function removeGroupMembers(
   await apiPost<void>(`/admin-api/groups/${groupId}/members/remove`, req);
 }
 
+/** `account` is the 64-hex `AccountId`; core's path segment is literally `:account`. */
 export async function updateMemberRole(
   groupId: string,
-  identity: string,
+  account: string,
   role: GroupRole,
 ): Promise<void> {
-  await apiPut<void>(`/admin-api/groups/${groupId}/members/${identity}/role`, {
+  await apiPut<void>(`/admin-api/groups/${groupId}/members/${account}/role`, {
     role,
   });
 }
@@ -417,13 +498,8 @@ export async function createGroupInvitation(
   return apiPost<InvitationPayload>(`/admin-api/groups/${groupId}/invite`, {});
 }
 
-export async function joinGroup(
-  req: InvitationPayload,
-): Promise<{ groupId: string; memberIdentity: string }> {
-  return apiPost<{ groupId: string; memberIdentity: string }>(
-    '/admin-api/groups/join',
-    req,
-  );
+export async function joinGroup(req: InvitationPayload): Promise<JoinResult> {
+  return apiPost<JoinResult>('/admin-api/groups/join', req);
 }
 
 export async function setSubgroupVisibility(
@@ -458,13 +534,14 @@ export async function getGroupMetadata(
   return apiGet<MetadataRecord | null>(`/admin-api/groups/${groupId}/metadata`);
 }
 
+/** `account` is the 64-hex `AccountId`, not the key the member signs with. */
 export async function setMemberMetadata(
   groupId: string,
-  identity: string,
+  account: string,
   req: { name?: string; data?: Record<string, string> },
 ): Promise<void> {
   await apiPut<void>(
-    `/admin-api/groups/${groupId}/members/${identity}/metadata`,
+    `/admin-api/groups/${groupId}/members/${account}/metadata`,
     {
       ...(req.name !== undefined ? { name: req.name } : {}),
       data: req.data ?? {},

--- a/src/components/namespaces/MembersSection.tsx
+++ b/src/components/namespaces/MembersSection.tsx
@@ -9,6 +9,7 @@ import {
 import {
   addGroupMembers,
   listGroupMembers,
+  looksLikeAccountId,
   removeGroupMembers,
   setMemberMetadata,
   updateMemberRole,
@@ -16,6 +17,7 @@ import {
   type GroupMembersResult,
   type GroupRole,
 } from '../../api/namespaceApi';
+import { useNodeIdentity } from './useNodeIdentity';
 import {
   ConfirmButton,
   CopyBtn,
@@ -41,6 +43,10 @@ function neighbour(role: string, direction: 1 | -1): GroupRole | null {
 /**
  * Members of a namespace or subgroup — the same endpoint backs both, because a
  * namespace IS a group (a root one).
+ *
+ * Every id in this table is an ACCOUNT (64 hex). Since core 0.11.0-rc.23 a
+ * membership row is keyed by the person, not by one of their device keys, so
+ * two devices belonging to one person are one row here.
  */
 export function MembersSection({
   groupId,
@@ -50,14 +56,18 @@ export function MembersSection({
   groupId: string;
   showToast: ShowToast;
   /**
-   * Reports the member list up to the page, which needs it for the member
-   * count and — via `selfIdentity` — to decide whether the header offers
-   * Delete (admin) or Leave (everyone else).
+   * Reports the member list up to the page, which needs it for the member count
+   * and — matched against this node's account — to decide whether the header
+   * offers Delete (admin) or Leave (everyone else). The page reads the account
+   * from `useNodeIdentity()` itself; the list no longer carries it.
    */
   onLoaded?: (result: GroupMembersResult) => void;
 }) {
   const [members, setMembers] = useState<GroupMember[]>([]);
-  const [selfIdentity, setSelfIdentity] = useState<string | undefined>();
+  // Which row is "you". rc.23 removed `selfIdentity` from the member-list
+  // response, so this is the node's own account compared against each row.
+  const nodeIdentity = useNodeIdentity();
+  const selfAccount = nodeIdentity?.accountId;
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState<string | null>(null);
   const [showAdd, setShowAdd] = useState(false);
@@ -70,24 +80,20 @@ export function MembersSection({
   const onLoadedRef = useRef(onLoaded);
   onLoadedRef.current = onLoaded;
 
-  const publish = useCallback(
-    (next: GroupMember[], identity: string | undefined) => {
-      onLoadedRef.current?.({ members: next, selfIdentity: identity });
-    },
-    [],
-  );
+  const publish = useCallback((next: GroupMember[]) => {
+    onLoadedRef.current?.({ members: next });
+  }, []);
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
       const result = await listGroupMembers(groupId);
       setMembers(result.members);
-      setSelfIdentity(result.selfIdentity);
-      publish(result.members, result.selfIdentity);
+      publish(result.members);
     } catch (e: unknown) {
       showToast(errorMessage(e, 'Failed to load members'), 'error');
       setMembers([]);
-      publish([], undefined);
+      publish([]);
     } finally {
       setLoading(false);
     }
@@ -100,15 +106,15 @@ export function MembersSection({
     load();
   }, [load]);
 
-  const changeRole = async (identity: string, role: GroupRole) => {
-    setBusy(identity);
+  const changeRole = async (account: string, role: GroupRole) => {
+    setBusy(account);
     try {
-      await updateMemberRole(groupId, identity, role);
+      await updateMemberRole(groupId, account, role);
       setMembers((prev) => {
         const next = prev.map((m) =>
-          m.identity === identity ? { ...m, role } : m,
+          m.identity === account ? { ...m, role } : m,
         );
-        publish(next, selfIdentity);
+        publish(next);
         return next;
       });
       showToast(`Role set to ${role}`, 'success');
@@ -119,13 +125,15 @@ export function MembersSection({
     }
   };
 
-  const remove = async (identity: string) => {
-    setBusy(identity);
+  const remove = async (account: string) => {
+    setBusy(account);
     try {
-      await removeGroupMembers(groupId, { members: [identity] });
+      // `members` here is a list of ACCOUNTS — the same ids the listing gave
+      // us. Sending the key a member signs with addresses nobody.
+      await removeGroupMembers(groupId, { members: [account] });
       setMembers((prev) => {
-        const next = prev.filter((m) => m.identity !== identity);
-        publish(next, selfIdentity);
+        const next = prev.filter((m) => m.identity !== account);
+        publish(next);
         return next;
       });
       showToast('Member removed', 'success');
@@ -136,12 +144,12 @@ export function MembersSection({
     }
   };
 
-  const rename = async (identity: string, name: string) => {
-    setBusy(identity);
+  const rename = async (account: string, name: string) => {
+    setBusy(account);
     try {
-      await setMemberMetadata(groupId, identity, { name });
+      await setMemberMetadata(groupId, account, { name });
       setMembers((prev) =>
-        prev.map((m) => (m.identity === identity ? { ...m, name } : m)),
+        prev.map((m) => (m.identity === account ? { ...m, name } : m)),
       );
       showToast('Member renamed', 'success');
     } catch (e: unknown) {
@@ -151,9 +159,14 @@ export function MembersSection({
     }
   };
 
+  // Add is the only member call that names a KEY rather than an account, so an
+  // id copied out of the table below (an account) silently addresses nobody
+  // here. Warn on the shape rather than let the node answer with a bare error.
+  const pastedAnAccount = looksLikeAccountId(newIdentity);
+
   const add = async () => {
     const identity = newIdentity.trim();
-    if (!identity) return;
+    if (!identity || pastedAnAccount) return;
     setAdding(true);
     try {
       await addGroupMembers(groupId, {
@@ -198,7 +211,9 @@ export function MembersSection({
           <input
             className="ns-input"
             type="text"
-            placeholder="Identity (public key)"
+            placeholder="Public key (base58)"
+            aria-label="Public key of the new member"
+            title="A public key, base58 — NOT the 64-hex account shown in the table. An add is the one call whose subject may not have an account on this node yet."
             value={newIdentity}
             onChange={(e) => setNewIdentity(e.target.value)}
             style={{ flex: 1, minWidth: 220 }}
@@ -221,7 +236,7 @@ export function MembersSection({
           <button
             className="btn btn-primary btn-sm"
             onClick={add}
-            disabled={adding || !newIdentity.trim()}
+            disabled={adding || !newIdentity.trim() || pastedAnAccount}
           >
             {adding ? 'Adding…' : 'Add'}
           </button>
@@ -234,6 +249,13 @@ export function MembersSection({
           >
             Cancel
           </button>
+          {pastedAnAccount && (
+            <p className="ns-muted" data-testid="ns-add-member-hint">
+              That looks like an account (64 hex). Add takes the public key the
+              person signs with, in base58 — the account is what the node
+              derives and shows back in the table.
+            </p>
+          )}
         </div>
       )}
 
@@ -246,14 +268,16 @@ export function MembersSection({
           <thead>
             <tr>
               <th>Name</th>
-              <th>Identity</th>
+              <th title="The member's account, 64 hex characters. A person, not a device key — one person with two devices is one row.">
+                Account
+              </th>
               <th>Role</th>
               <th className="ns-table-right">Actions</th>
             </tr>
           </thead>
           <tbody>
             {members.map((m) => {
-              const isSelf = !!selfIdentity && m.identity === selfIdentity;
+              const isSelf = !!selfAccount && m.identity === selfAccount;
               const higher = neighbour(m.role, 1);
               const lower = neighbour(m.role, -1);
               return (

--- a/src/components/namespaces/useNodeIdentity.ts
+++ b/src/components/namespaces/useNodeIdentity.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { getNodeIdentity, type NodeIdentity } from '../../api/namespaceApi';
+
+/**
+ * Who this node is, fetched once and shared by every caller.
+ *
+ * Three places need it and they are on screen together: the members table
+ * marking a row "you", and both detail headers choosing between Delete (admin)
+ * and Leave (everyone else). Until core 0.11.0-rc.23 all three read
+ * `selfIdentity` off the member-list response and no extra request existed;
+ * that field is gone (#3522, and the list now carries `members` and nothing
+ * else), so the answer has to come from `GET /admin-api/identity`.
+ *
+ * There is deliberately no cache key. The route takes no namespace and the
+ * answer does not vary by one — one root key is one account everywhere on a
+ * node — which is the same fact that got the per-namespace route deleted. So a
+ * single in-flight promise is the whole cache.
+ *
+ * A miss is a NORMAL state, not an error: the route 404s on a node that has
+ * taken part in nothing yet, because it holds neither a device nor an account
+ * root. The UI just cannot mark anyone as "you", and must not toast about it.
+ */
+let pending: Promise<NodeIdentity | null> | null = null;
+
+function load(): Promise<NodeIdentity | null> {
+  pending ??= getNodeIdentity().catch(() => {
+    // Don't let a transient failure become permanent. The rejection handler
+    // runs after the assignment above, so clearing it here makes the next
+    // mount retry rather than believing forever that this node has no account.
+    pending = null;
+    return null;
+  });
+  return pending;
+}
+
+/** Test-only: drop the shared promise so the next mount refetches. */
+export function resetNodeIdentity(): void {
+  pending = null;
+}
+
+export function useNodeIdentity(): NodeIdentity | null {
+  const [identity, setIdentity] = useState<NodeIdentity | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    void load().then((result) => {
+      if (live) setIdentity(result);
+    });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  return identity;
+}

--- a/src/pages/Namespaces.tsx
+++ b/src/pages/Namespaces.tsx
@@ -24,7 +24,6 @@ import {
   deleteGroup,
   deleteNamespace,
   getGroupInfo,
-  getNamespaceIdentity,
   joinGroup,
   joinNamespace,
   leaveGroup,
@@ -50,6 +49,7 @@ import {
 } from '../components/namespaces/CreateContextPanel';
 import { InvitePanel, JoinPanel } from '../components/namespaces/InvitePanel';
 import { MembersSection } from '../components/namespaces/MembersSection';
+import { useNodeIdentity } from '../components/namespaces/useNodeIdentity';
 import { StructureTree } from '../components/namespaces/StructureTree';
 import {
   ConfirmButton,
@@ -606,7 +606,11 @@ function NamespaceDetail({
   showToast: ShowToast;
 }) {
   const [ns, setNs] = useState(initialNs);
-  const [identity, setIdentity] = useState<string | null>(null);
+  // Node-level, not per-namespace. `GET /namespaces/:id/identity` is gone
+  // (core #3522): it took a namespace and answered with the node's account
+  // whichever one you passed, because every namespace on a node resolves to the
+  // same account. `GET /admin-api/identity` says that plainly.
+  const identity = useNodeIdentity();
   const [panel, setPanel] = useState<Panel>(null);
   const [busy, setBusy] = useState(false);
   const [treeVersion, setTreeVersion] = useState(0);
@@ -619,12 +623,6 @@ function NamespaceDetail({
     partial,
   } = useNamespaceTree(ns.namespaceId, treeVersion);
 
-  useEffect(() => {
-    getNamespaceIdentity(ns.namespaceId)
-      .then((id) => setIdentity(id.publicKey))
-      .catch(() => setIdentity(null));
-  }, [ns.namespaceId]);
-
   const appName = installedApps.find(
     (a) => a.id === ns.targetApplicationId,
   )?.name;
@@ -632,8 +630,12 @@ function NamespaceDetail({
   // Delete is admin-gated on the node; a plain member's only exit is Leave.
   // While the role is still unknown, keep offering Delete — the node enforces
   // it anyway, so the worst case is an error toast rather than a hidden action.
-  const myRole = self?.selfIdentity
-    ? self.members.find((m) => m.identity === self.selfIdentity)?.role
+  //
+  // Our own row is found by ACCOUNT. The member list used to carry a
+  // `selfIdentity` field and rc.23 removed it, so the match is against the
+  // node's own account id — which is what the rows are keyed by anyway.
+  const myRole = identity
+    ? self?.members.find((m) => m.identity === identity.accountId)?.role
     : undefined;
   const showLeave =
     myRole !== undefined && String(myRole).toLowerCase() !== 'admin';
@@ -877,16 +879,56 @@ function NamespaceDetail({
             <span className="ns-kv-value">{ns.appVersion}</span>
           </div>
         )}
-        {identity && (
+      </div>
+
+      {/* Not "your namespace identity" — there is no such thing. Every
+          namespace on this node resolves to the same account, which is why
+          core deleted the per-namespace route (#3522) in favour of a node-level
+          one. The account is the id the members table is keyed by; the signing
+          key never appears there, so both are labelled for what they are. */}
+      {identity && (
+        <div className="ns-section" data-testid="ns-identity-section">
+          <h2>This node</h2>
           <div className="ns-kv-row">
-            <span className="ns-kv-label">Your namespace identity</span>
+            <span
+              className="ns-kv-label"
+              title="Node-level, not per-namespace. This is the id that appears as your row in the members table below."
+            >
+              Your account
+            </span>
             <span className="ns-kv-value mono">
-              {truncate(identity, 40)}
-              <CopyBtn value={identity} />
+              {truncate(identity.accountId, 40)}
+              <CopyBtn value={identity.accountId} />
             </span>
           </div>
-        )}
-      </div>
+          {identity.deviceId && (
+            <div className="ns-kv-row">
+              <span
+                className="ns-kv-label"
+                title="This installation. Several devices can share one account, and membership is recorded against the account, not this."
+              >
+                Device
+              </span>
+              <span className="ns-kv-value mono">
+                {truncate(identity.deviceId, 40)}
+                <CopyBtn value={identity.deviceId} />
+              </span>
+            </div>
+          )}
+          <div className="ns-kv-row">
+            <span
+              className="ns-kv-label"
+              title="Base58, and the only base58 id on this page. It is what an operator adding you to a group types in — the add endpoint names a key, everything else names an account."
+            >
+              Signing key
+            </span>
+            <span className="ns-kv-value mono">
+              {truncate(identity.publicKey, 40)}
+              <CopyBtn value={identity.publicKey} />
+            </span>
+          </div>
+        </div>
+      )}
 
       <div className="ns-section">
         <div className="ns-section-header">
@@ -996,6 +1038,7 @@ function GroupDetail({
   const [panel, setPanel] = useState<Panel>(null);
   const [busy, setBusy] = useState(false);
   const [self, setSelf] = useState<GroupMembersResult | null>(null);
+  const identity = useNodeIdentity();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -1022,8 +1065,10 @@ function GroupDetail({
   }, [load]);
 
   const name = info?.metadata?.name ?? undefined;
-  const myRole = self?.selfIdentity
-    ? self.members.find((m) => m.identity === self.selfIdentity)?.role
+  // Same as the namespace header: match our own ACCOUNT against the rows,
+  // because rc.23 dropped `selfIdentity` from the member-list response.
+  const myRole = identity
+    ? self?.members.find((m) => m.identity === identity.accountId)?.role
     : undefined;
   const showLeave =
     myRole !== undefined && String(myRole).toLowerCase() !== 'admin';

--- a/src/test/namespaceApi.test.ts
+++ b/src/test/namespaceApi.test.ts
@@ -4,6 +4,8 @@ import {
   leaveNamespace,
   leaveGroup,
   leaveContext,
+  getNodeIdentity,
+  looksLikeAccountId,
   updateMemberRole,
   removeGroupMembers,
   addGroupMembers,
@@ -13,6 +15,17 @@ import {
   listSubgroups,
   setGroupMetadata,
 } from '../api/namespaceApi';
+
+/**
+ * Ids in these fixtures are shaped the way the wire shapes them, because the
+ * shapes are half of what is under test: an ACCOUNT is 64 hex characters and a
+ * KEY is base58. Since core 0.11.0-rc.23 every member call but `add` names the
+ * account, and using a stand-in string like 'identity-pub-key' everywhere hides
+ * exactly the mix-up these tests are here to catch.
+ */
+const ACCOUNT = 'a'.repeat(64);
+const OTHER_ACCOUNT = 'b'.repeat(64);
+const PUBLIC_KEY = '2Fb1JXPZQZmGRoLPS9F6JsPRRTL1cKnQfCzYAeZLmDaG';
 
 // Mock calimero-client before importing namespaceApi
 vi.mock('@calimero-network/calimero-client', () => ({
@@ -104,9 +117,11 @@ describe('leaveContext', () => {
 describe('updateMemberRole', () => {
   it('PUTs role to Admin (promote)', async () => {
     mockFetch.mockReturnValueOnce(okResponse());
-    await updateMemberRole('grp-1', 'identity-pub-key', 'Admin');
+    // The path segment is core's `:account`, so this is the 64-hex account
+    // the listing returned — not the key the member signs with.
+    await updateMemberRole('grp-1', ACCOUNT, 'Admin');
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://localhost:2428/admin-api/groups/grp-1/members/identity-pub-key/role',
+      `http://localhost:2428/admin-api/groups/grp-1/members/${ACCOUNT}/role`,
       expect.objectContaining({
         method: 'PUT',
         body: JSON.stringify({ role: 'Admin' }),
@@ -116,7 +131,7 @@ describe('updateMemberRole', () => {
 
   it('PUTs role to Member (demote)', async () => {
     mockFetch.mockReturnValueOnce(okResponse());
-    await updateMemberRole('grp-1', 'identity-pub-key', 'Member');
+    await updateMemberRole('grp-1', ACCOUNT, 'Member');
     const call = mockFetch.mock.calls[0];
     expect(call).toBeDefined();
     if (!call) return;
@@ -125,23 +140,23 @@ describe('updateMemberRole', () => {
 
   it('throws on non-OK response', async () => {
     mockFetch.mockReturnValueOnce(errResponse(400, 'Bad Request'));
-    await expect(
-      updateMemberRole('grp-1', 'identity-pub-key', 'Admin'),
-    ).rejects.toThrow('400');
+    await expect(updateMemberRole('grp-1', ACCOUNT, 'Admin')).rejects.toThrow(
+      '400',
+    );
   });
 });
 
 // ── removeGroupMembers (kick) ─────────────────────────────────────────────────
 
 describe('removeGroupMembers (kick)', () => {
-  it('POSTs to /members/remove with identity list', async () => {
+  it('POSTs to /members/remove with an ACCOUNT list', async () => {
     mockFetch.mockReturnValueOnce(okResponse());
-    await removeGroupMembers('grp-1', { members: ['identity-pub-key'] });
+    await removeGroupMembers('grp-1', { members: [OTHER_ACCOUNT] });
     expect(mockFetch).toHaveBeenCalledWith(
       'http://localhost:2428/admin-api/groups/grp-1/members/remove',
       expect.objectContaining({
         method: 'POST',
-        body: JSON.stringify({ members: ['identity-pub-key'] }),
+        body: JSON.stringify({ members: [OTHER_ACCOUNT] }),
       }),
     );
   });
@@ -149,7 +164,7 @@ describe('removeGroupMembers (kick)', () => {
   it('throws on non-OK response', async () => {
     mockFetch.mockReturnValueOnce(errResponse(403, 'Forbidden'));
     await expect(
-      removeGroupMembers('grp-1', { members: ['key'] }),
+      removeGroupMembers('grp-1', { members: [OTHER_ACCOUNT] }),
     ).rejects.toThrow('403');
   });
 });
@@ -157,18 +172,77 @@ describe('removeGroupMembers (kick)', () => {
 // ── addGroupMembers ───────────────────────────────────────────────────────────
 
 describe('addGroupMembers', () => {
-  it('POSTs new member with role', async () => {
+  // The ONE member call that still names a key. An add's subject may hold no
+  // account on this node yet — the account is a hash of a genesis the node only
+  // learns once they have joined — so requiring one would make the endpoint
+  // uncallable in exactly the case it exists for.
+  it('POSTs new member as a KEY, not an account', async () => {
     mockFetch.mockReturnValueOnce(okResponse());
     await addGroupMembers('grp-1', {
-      members: [{ identity: 'new-key', role: 'Member' }],
+      members: [{ identity: PUBLIC_KEY, role: 'Member' }],
     });
     const call = mockFetch.mock.calls[0];
     expect(call).toBeDefined();
     if (!call) return;
     expect(call[0]).toContain('/admin-api/groups/grp-1/members');
     expect(JSON.parse(call[1].body)).toEqual({
-      members: [{ identity: 'new-key', role: 'Member' }],
+      members: [{ identity: PUBLIC_KEY, role: 'Member' }],
     });
+  });
+});
+
+// ── Account vs key ────────────────────────────────────────────────────────────
+
+describe('looksLikeAccountId', () => {
+  // The UI uses this to stop an account being pasted into the add-member box,
+  // which is the one field that wants a key. Base58 has no `0`, so a
+  // 64-character all-hex string is an account with near-certainty.
+  it('recognises a 64-hex account', () => {
+    expect(looksLikeAccountId(ACCOUNT)).toBe(true);
+    expect(looksLikeAccountId(`  ${ACCOUNT}  `)).toBe(true);
+  });
+
+  it('rejects a base58 public key', () => {
+    expect(looksLikeAccountId(PUBLIC_KEY)).toBe(false);
+    expect(looksLikeAccountId('')).toBe(false);
+    expect(looksLikeAccountId('a'.repeat(63))).toBe(false);
+  });
+});
+
+// ── Node identity ─────────────────────────────────────────────────────────────
+
+describe('getNodeIdentity', () => {
+  // rc.23 deleted `GET /namespaces/:id/identity` (#3522). It took a namespace
+  // and answered with the node's account whichever one you passed, so this
+  // route has no namespace in it at all — that is the entire change.
+  it('GETs the node-level route and unwraps { data }', async () => {
+    mockFetch.mockReturnValueOnce(
+      okResponse({
+        data: {
+          accountId: ACCOUNT,
+          deviceId: 'd'.repeat(64),
+          publicKey: PUBLIC_KEY,
+          accountRootPublicKey: 'r'.repeat(64),
+        },
+      }),
+    );
+    const identity = await getNodeIdentity();
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:2428/admin-api/identity',
+      expect.anything(),
+    );
+    expect(identity.accountId).toBe(ACCOUNT);
+    expect(identity.publicKey).toBe(PUBLIC_KEY);
+  });
+
+  // A node that has taken part in nothing holds neither a device nor an
+  // account root, so there is no account to report rather than an empty one.
+  // Callers treat the rejection as "unknown", never as a failure worth a toast.
+  it('rejects when the node has no identity yet', async () => {
+    mockFetch.mockReturnValueOnce(
+      errResponse(404, JSON.stringify({ error: 'this node holds neither' })),
+    );
+    await expect(getNodeIdentity()).rejects.toThrow('404');
   });
 });
 
@@ -188,16 +262,19 @@ describe('response envelopes', () => {
     expect(result[0]?.name).toBe('Team');
   });
 
-  it('listGroupMembers reads { members, selfIdentity } — NOT { data }', async () => {
+  // rc.23 carries `members` and NOTHING else — `selfIdentity` is gone. The
+  // fixture keeps the ids account-shaped so a reader can see what a row holds.
+  it('listGroupMembers reads { members } — NOT { data }', async () => {
     mockFetch.mockReturnValueOnce(
       okResponse({
-        members: [{ identity: 'k1', role: 'Admin', name: 'Fran' }],
-        selfIdentity: 'k1',
+        members: [{ identity: ACCOUNT, role: 'Admin', name: 'Fran' }],
       }),
     );
     const result = await listGroupMembers('grp-1');
     expect(result.members).toHaveLength(1);
-    expect(result.selfIdentity).toBe('k1');
+    expect(result.members[0]?.identity).toBe(ACCOUNT);
+    // Nothing may reintroduce a self field by reading it off the response.
+    expect(Object.keys(result)).toEqual(['members']);
   });
 
   it('listSubgroups reads { subgroups } — NOT { data }', async () => {


### PR DESCRIPTION
`1.13.0` shipped yesterday against **rc.22** and is broken against **rc.23**, released this morning. Two things it depends on are gone.

## What broke

**`GET /admin-api/namespaces/:id/identity` is deleted** (core #3522).

It was a lie with an extra path segment: it took a namespace and answered with the node's account whichever one you passed, because every namespace on a node resolves to the same account. Replaced by node-level **`GET /admin-api/identity`** → `{accountId, deviceId?, publicKey}`.

The section is relabelled **"This node"**, and each id is labelled for what it actually is — the old "Your namespace identity" named something that does not exist.

**`selfIdentity` is gone from the member listing.** That is how the "you" badge and the Delete-vs-Leave choice worked. The response now carries `members` and nothing else, so both read the node's account and compare against `member.identity` — which is what the rows are keyed by anyway.

**Members are accounts now** — `identity` is 64 hex, not the base58 a key renders as. Core states the reason plainly: *a member is a person here, and a person may hold several keys.*

## The asymmetry this surfaced

`POST /groups/:id/members` is the **only** member verb still naming a **key** (base58). Core's own comment explains why: an add is the only call whose subject may have no account on this node yet — the account is a hash of a genesis the node learns only once they have joined — so an operator can only name them by the key they sign with. Listing, remove, role, capabilities and metadata all take the **account**.

The two encodings render differently *specifically* so a mix-up fails loudly instead of resolving to the wrong principal. Pasting an id out of the members table into add-member therefore addresses nobody, so `looksLikeAccountId()` lets the form say so.

## Also

- Drops `requester` from request bodies — core #3492 removed the field everywhere.
- Pins the live suite's merod to **rc.23**. A suite pinned to rc.20 would happily keep passing against shapes the node no longer sends, which is precisely how this regression reached a release.
- Mocked fixtures and unit tests updated to the rc.23 shapes, so they pin the new contract rather than the old one.

## ⚠️ Not built or tested locally

The machine this was written on could not afford another build, so **CI is the first thing to compile or run this**. Every shape here was read directly out of `calimero-network/core` at tag `0.11.0-rc.23` (`crates/server/primitives/src/admin/mod.rs` and `crates/server/src/admin/service.rs`) rather than inferred — but the code itself is unexecuted. Please treat a red check as expected-until-proven rather than surprising.

`build/` is deliberately untouched: it is tracked in this repo, and committing a bundle I could not rebuild from this source would be worse than leaving it to the release pipeline.